### PR TITLE
Improve Request

### DIFF
--- a/Sources/Controllers/FormController.swift
+++ b/Sources/Controllers/FormController.swift
@@ -10,7 +10,7 @@ public class FormController: Controller {
   }
 
   public func process(_ request: Request) -> Response {
-    guard request.verb == "GET" else {
+    guard request.verb == .Get else {
       contents.update(request.pathName, withVal: request.body ?? "")
 
       return Response(status: TwoHundred.Ok, headers: [:], body: nil)

--- a/Sources/Controllers/LogsController.swift
+++ b/Sources/Controllers/LogsController.swift
@@ -11,7 +11,8 @@ public class LogsController: Controller {
 
   public func updateLogs(_ request: Request) {
     let existingLogs = contents.get("logs")
-    contents.update("logs", withVal: existingLogs + "\n\(request.verb) \(request.path) HTTP/1.1")
+    let verb = request.verb.rawValue.uppercased()
+    contents.update("logs", withVal: existingLogs + "\n\(verb) \(request.path) HTTP/1.1")
   }
 
   public func process(_ request: Request) -> Response {

--- a/Sources/Controllers/PartialContentsController.swift
+++ b/Sources/Controllers/PartialContentsController.swift
@@ -17,11 +17,11 @@ public class PartialContentsController: Controller {
 
     let range = getRange(of: splitRange.last!, length: content.characters.count)
 
-    let finalContents = chars[range].joined(separator: "")
+    let partialContents = chars[range].joined(separator: "")
 
     return Response(status: TwoHundred.PartialContent,
                     headers: ["Content-Type": "text/plain"],
-                    body: Array(finalContents.utf8))
+                    body: Array(partialContents.utf8))
   }
 
 }

--- a/Sources/Controllers/ResourcesController.swift
+++ b/Sources/Controllers/ResourcesController.swift
@@ -11,7 +11,7 @@ public class ResourcesController: Controller {
   }
 
   public func process(_ request: Request) -> Response {
-    guard request.verb != "PATCH" else {
+    guard request.verb != .Patch else {
       contents.update(request.pathName, withVal: request.body ?? "")
 
       return Response(status: TwoHundred.NoContent, headers: [:], body: nil)
@@ -23,7 +23,7 @@ public class ResourcesController: Controller {
       ).process(request)
     }
 
-    guard request.verb == "GET" else {
+    guard request.verb == .Get else {
       return Response(status: FourHundred.MethodNotAllowed, headers: [:], body: nil)
     }
 

--- a/Sources/Errors/Errors.swift
+++ b/Sources/Errors/Errors.swift
@@ -3,3 +3,7 @@ public enum ServerStartError: Error {
   case InvalidPublicDirectoryGiven
   case MissingArgumentFor(flag: String)
 }
+
+public enum BadRequestError: Error {
+  case InvalidRequest(for: String)
+}

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -6,14 +6,14 @@ class RequestTest: XCTestCase {
         let rawRequest = "GET /log HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
         let request = Request(for: rawRequest)
 
-        XCTAssertEqual(request.verb, "GET")
+        XCTAssertEqual(request.verb, .Get)
     }
 
     func testItTakesRawRequestAndExtractsVerbPOST() {
         let rawRequest = "POST /log HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
         let request = Request(for: rawRequest)
 
-        XCTAssertEqual(request.verb, "POST")
+        XCTAssertEqual(request.verb, .Post)
     }
 
     func testItTakesRawRequestAndExtractsPathLog() {
@@ -58,11 +58,10 @@ class RequestTest: XCTestCase {
         XCTAssertEqual(request.headers, expectedResult)
     }
 
-    func testItCanTranslateEmptyHeaderValues() {
+    func testItIgnoresEmptyHeaders() {
         let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
         let request = Request(for: rawRequest)
         let expectedResult = [
-          "host": "",
           "connection": "Keep-Alive",
           "user-agent": "chrome",
           "accept-encoding": "gzip,deflate"
@@ -135,5 +134,12 @@ class RequestTest: XCTestCase {
       let request = Request(for: rawRequest)
 
       XCTAssertEqual(request.pathName, "form")
+    }
+
+    func testItCanHandleInvalidRequests() {
+      let rawRequest = "HAMSTER /somewhere"
+      let request = Request(for: rawRequest)
+
+      XCTAssertEqual(request.verb, .Invalid)
     }
 }


### PR DESCRIPTION
- HTTPRequestMethod enum as verb property instead of String
- Request filters out empty header values.
- crlf stored prop to Request.
- default assignment to headers
- extracted private function to handle creating array of Headers in Dictionary,