### PR TITLE
Response Protocol

### DIFF
--- a/Sources/Controllers/CoffeeController.swift
+++ b/Sources/Controllers/CoffeeController.swift
@@ -4,9 +4,8 @@ import Responses
 public class CoffeeController: Controller {
 
   public func process(_ request: Request) -> Response {
-    return Response(status: FourHundred.Teapot,
-                    headers: [:],
-                    body: Array("I'm a teapot".utf8))
+    return HTTPResponse(status: FourHundred.Teapot,
+                        body: "I'm a teapot")
   }
 
 }

--- a/Sources/Controllers/CookieController.swift
+++ b/Sources/Controllers/CookieController.swift
@@ -18,9 +18,9 @@ public class CookieController: Controller {
       body = "mmmm \(cookieValue)"
     }
 
-    return Response(status: TwoHundred.Ok,
-                    headers: headers,
-                    body: Array(body.utf8))
+    return HTTPResponse(status: TwoHundred.Ok,
+                        headers: headers,
+                        body: body)
   }
 
 }

--- a/Sources/Controllers/DefaultController.swift
+++ b/Sources/Controllers/DefaultController.swift
@@ -4,9 +4,7 @@ import Responses
 public class DefaultController: Controller {
 
   public func process(_ request: Request) -> Response {
-    return Response(status: TwoHundred.Ok,
-                    headers: ["Content-Type": "text/html"],
-                    body: nil)
+    return HTTPResponse(status: TwoHundred.Ok)
   }
 
 }

--- a/Sources/Controllers/FoobarController.swift
+++ b/Sources/Controllers/FoobarController.swift
@@ -4,9 +4,7 @@ import Responses
 public class FoobarController: Controller {
 
   public func process(_ request: Request) -> Response {
-    return Response(status: FourHundred.NotFound,
-                    headers: [:],
-                    body: nil)
+    return HTTPResponse(status: FourHundred.NotFound)
   }
 
 }

--- a/Sources/Controllers/FormController.swift
+++ b/Sources/Controllers/FormController.swift
@@ -13,15 +13,14 @@ public class FormController: Controller {
     guard request.verb == .Get else {
       contents.update(request.pathName, withVal: request.body ?? "")
 
-      return Response(status: TwoHundred.Ok, headers: [:], body: nil)
+      return HTTPResponse(status: TwoHundred.Ok)
     }
 
     let form = contents.get(request.pathName)
 
-    return Response(
+    return HTTPResponse(
       status: TwoHundred.Ok,
-      headers: [:],
-      body: form.isEmpty ? nil : Array(form.utf8)
+      body: form.isEmpty ? nil : form
     )
   }
 

--- a/Sources/Controllers/LogsController.swift
+++ b/Sources/Controllers/LogsController.swift
@@ -17,22 +17,21 @@ public class LogsController: Controller {
 
   public func process(_ request: Request) -> Response {
     let headers = [ "WWW-Authenticate": "Basic realm=\"simple\""]
-    let providedAuth = getBase64(of: authCredentials)!
 
-    let auth = request.headers["authorization"].flatMap {
+    let providedCredentials = request.headers["authorization"].flatMap {
       $0.components(separatedBy: " ").last
     } ?? ""
 
-    guard providedAuth == auth else {
-      return Response(status: FourHundred.Unauthorized, headers: headers, body: nil)
+    guard authCredentials == providedCredentials else {
+      return HTTPResponse(status: FourHundred.Unauthorized, headers: headers)
     }
 
     updateLogs(request)
 
-    return Response(
+    return HTTPResponse(
       status: TwoHundred.Ok,
       headers: headers,
-      body: contents.getBinary(request.pathName)
+      body: contents.get(request.pathName)
     )
   }
 

--- a/Sources/Controllers/MethodOptionsController.swift
+++ b/Sources/Controllers/MethodOptionsController.swift
@@ -8,9 +8,8 @@ class MethodOptionsController: Controller {
                                                   : "GET,HEAD,POST,OPTIONS,PUT"
     let headers = ["Allow": allowedVerbs]
 
-    return Response(status: TwoHundred.Ok,
-                    headers: headers,
-                    body: nil)
+    return HTTPResponse(status: TwoHundred.Ok,
+                        headers: headers)
   }
 
 }

--- a/Sources/Controllers/ParametersController.swift
+++ b/Sources/Controllers/ParametersController.swift
@@ -7,18 +7,14 @@ class ParametersController: Controller {
   public func process(_ request: Request) -> Response {
 
     let body = request.params.map { params in
-      Array(
-        params
-         .toDictionary()
-         .map { $0 + " = " + $1 }
-         .joined(separator: "\n")
-         .utf8
-      )
+      params
+       .toDictionary()
+       .map { $0 + " = " + $1 }
+       .joined(separator: "\n")
     }
 
-    return Response(status: TwoHundred.Ok,
-                    headers: [:],
-                    body: body)
+    return HTTPResponse(status: TwoHundred.Ok,
+                        body: body)
   }
 
 }

--- a/Sources/Controllers/PartialContentsController.swift
+++ b/Sources/Controllers/PartialContentsController.swift
@@ -5,23 +5,26 @@ import Util
 
 public class PartialContentsController: Controller {
   let content: String
+  let rangeHeader: String
 
-  public init(content: String) {
+  public init(content: String, range: String) {
     self.content = content
+    self.rangeHeader = range
   }
 
   public func process(_ request: Request) -> Response {
-    let splitRange = request.headers["range"]!.components(separatedBy: "=")
+    let splitRange = rangeHeader.components(separatedBy: "=")
+    let rawRange = splitRange[splitRange.index(before: splitRange.endIndex)]
 
-    let chars: [String] = Array(content.characters).map { String($0) }
+    let chars = Array(content.characters).map { String($0) }
 
-    let range = getRange(of: splitRange.last!, length: content.characters.count)
+    let range = getRange(of: rawRange, length: content.characters.count)
 
     let partialContents = chars[range].joined(separator: "")
 
-    return Response(status: TwoHundred.PartialContent,
-                    headers: ["Content-Type": "text/plain"],
-                    body: Array(partialContents.utf8))
+    return HTTPResponse(status: TwoHundred.PartialContent,
+                        headers: ["Content-Type": "text/plain"],
+                        body: partialContents)
   }
 
 }

--- a/Sources/Controllers/RedirectController.swift
+++ b/Sources/Controllers/RedirectController.swift
@@ -6,11 +6,7 @@ public class RedirectController: Controller {
   public func process(_ request: Request) -> Response {
     let headers: [String: String] = ["Location": "/"]
 
-    return Response(
-      status: ThreeHundred.Found,
-      headers: headers,
-      body: nil
-    )
+    return HTTPResponse(status: ThreeHundred.Found, headers: headers)
   }
 
 }

--- a/Sources/Controllers/RootController.swift
+++ b/Sources/Controllers/RootController.swift
@@ -14,9 +14,9 @@ public class RootController: Controller {
       "<a href=\"/\(file)\">\(file)</a>"
     }.joined(separator: "<br>")
 
-    return Response(status: TwoHundred.Ok,
-                    headers: ["Content-Type": "text/html"],
-                    body: Array(fileLinks.utf8))
+    return HTTPResponse(status: TwoHundred.Ok,
+                        headers: ["Content-Type": "text/html"],
+                        body: fileLinks)
 
   }
 

--- a/Sources/Responses/HTTPResponse.swift
+++ b/Sources/Responses/HTTPResponse.swift
@@ -1,0 +1,17 @@
+public class HTTPResponse: Response {
+  public let statusCode: String
+  public let headers: [String: String]
+  public let body: [UInt8]?
+
+  public required init(status: StatusCode, headers: [String: String], bodyBytes: [UInt8]?) {
+    self.statusCode = status.description
+    self.headers = headers
+    self.body = bodyBytes.map { Array("\n\n".utf8) + $0 }
+  }
+
+  public required init(status: StatusCode, headers: [String: String] = [:], body: String? = nil) {
+    self.statusCode = status.description
+    self.headers = headers
+    self.body = body.map { Array("\n\n\($0)".utf8) }
+  }
+}

--- a/Sources/Responses/Response.swift
+++ b/Sources/Responses/Response.swift
@@ -1,16 +1,19 @@
 import Foundation
-public class Response {
-  public let statusCode: String
-  public let headers: [String: String]
-  public let body: [UInt8]?
 
-  public init(status: StatusCode, headers: [String: String], body: [UInt8]?) {
-    self.statusCode = status.description
+public protocol Response {
+  var statusCode: String { get }
+  var headers: [String: String] { get }
+  var body: [UInt8]? { get }
+  var formatted: [UInt8] { get }
 
-    self.headers = headers
-    self.body = body.map { Array("\n\n".utf8) + $0 }
-  }
+  init(status: StatusCode, headers: [String: String], body: String?)
 
+  init(status: StatusCode, headers: [String: String], bodyBytes: [UInt8]?)
+
+  func toString() -> String
+}
+
+extension Response {
   public var formatted: [UInt8] {
     let joinedHeaders = headers.map { $0 + ":" + $1 }.joined(separator: "\r\n")
     let statusLine = "HTTP/1.1 \(statusCode)\r\n"

--- a/Sources/Util/Util.swift
+++ b/Sources/Util/Util.swift
@@ -1,13 +1,6 @@
 import Foundation
 import Errors
 
-public func getBase64(of input: String) -> String? {
-  let data = input.data(using: .utf8)
-  return data.map {
-    $0.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
-  }
-}
-
 public func formatTimestamp(prefix: String) -> String {
   let dateHelper = DateHelper()
   let currentTime = dateHelper.time(separator: ":")
@@ -37,4 +30,4 @@ public func getRange(of rawRange: String, length contentLength: Int) -> Range<In
 
 public let logsPath = "/Users/patrickwentz/8th-light/projects/swift/server/Sources/Server/Debug"
 public let defaultPublicDirPath = "/Users/patrickwentz/cob_spec/public"
-public let authCredentials = "admin:hunter2"
+public let authCredentials = "YWRtaW46aHVudGVyMg=="

--- a/Tests/ControllersTests/PartialContentsController.swift
+++ b/Tests/ControllersTests/PartialContentsController.swift
@@ -6,10 +6,11 @@ class PartialContentsControllerTest: XCTestCase {
   func testItCanRespondWithA206WithPartialContent() {
     let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate\r\nRange:bytes=4-"
     let request = Request(for: rawRequest)
+    let range = request.headers["range"]!
 
     let content = "This is a file that contains text to read part of in order to fulfill a 206."
 
-    let response = PartialContentsController(content: content).process(request)
+    let response = PartialContentsController(content: content, range: range).process(request)
 
     XCTAssertEqual(response.statusCode, "206 Partial Content")
   }
@@ -17,10 +18,11 @@ class PartialContentsControllerTest: XCTestCase {
   func testItCanRespondWithPartialContentsGivenRangeStart() {
     let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\nRange:bytes=4-\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
     let request = Request(for: rawRequest)
+    let range = request.headers["range"]!
 
     let content = "This is a file that contains text to read part of in order to fulfill a 206."
 
-    let response = PartialContentsController(content: content).process(request)
+    let response = PartialContentsController(content: content, range: range).process(request)
 
     let expected = Array("\n\n is a file that contains text to read part of in order to fulfill a 206.".utf8)
 
@@ -30,10 +32,11 @@ class PartialContentsControllerTest: XCTestCase {
   func testItCanRespondWithPartialContentsGivenRangeEnd() {
     let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\nRange:bytes=-6\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
     let request = Request(for: rawRequest)
+    let range = request.headers["range"]!
 
     let content = "This is a file that contains text to read part of in order to fulfill a 206."
 
-    let response = PartialContentsController(content: content).process(request)
+    let response = PartialContentsController(content: content, range: range).process(request)
 
     let expected = Array("\n\na 206.".utf8)
 
@@ -43,10 +46,11 @@ class PartialContentsControllerTest: XCTestCase {
   func testItCanRespondWithPartialContentsGivenRangeStartAndEnd() {
     let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\nRange:bytes=0-4\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
     let request = Request(for: rawRequest)
+    let range = request.headers["range"]!
 
     let content = "This is a file that contains text to read part of in order to fulfill a 206."
 
-    let response = PartialContentsController(content: content).process(request)
+    let response = PartialContentsController(content: content, range: range).process(request)
 
     let expected = Array("\n\nThis ".utf8)
 

--- a/Tests/ResponsesTests/ResponseTest.swift
+++ b/Tests/ResponsesTests/ResponseTest.swift
@@ -6,28 +6,28 @@ class ResponseTest: XCTestCase {
 
   func testItCanCompleteAStatusCode() {
     let headers = ["Content-Type": "ABCD"]
-    let body = Array("BODY".utf8)
+    let body = "BODY"
 
-    let response = Response(status: ok, headers: headers, body: body)
+    let response = HTTPResponse(status: ok, headers: headers, body: body)
 
     XCTAssertEqual(response.statusCode, "200 OK")
   }
 
   func testItCanCompleteOtherStatusCodes() {
     let headers = ["Content-Type": "ABCD"]
-    let body = Array("BODY".utf8)
+    let body = "BODY"
 
-    let response = Response(status: FourHundred.Teapot, headers: headers, body: body)
+    let response = HTTPResponse(status: FourHundred.Teapot, headers: headers, body: body)
 
     XCTAssertEqual(response.statusCode, "418 I'm a teapot")
   }
 
   func testItCanFormatItsBody() {
     let headers = ["Content-Type": "ABCD"]
-    let body = Array("BODY".utf8)
+    let body = "BODY"
 
-    let response = Response(status: ok, headers: headers, body: body)
-    let expected: [UInt8] = Array("\n\n".utf8) + body
+    let response = HTTPResponse(status: ok, headers: headers, body: body)
+    let expected: [UInt8] = Array("\n\n\(body)".utf8)
 
     XCTAssertEqual(response.body!, expected)
   }
@@ -36,9 +36,9 @@ class ResponseTest: XCTestCase {
     let headers = ["Content-Type": "text/html",
                    "WWW-Authenticate" : "Basic realm=\"simple\""]
 
-    let body = Array("BODY".utf8)
+    let body = "BODY"
 
-    let response = Response(status: ok, headers: headers, body: body)
+    let response = HTTPResponse(status: ok, headers: headers, body: body)
 
     XCTAssertEqual(response.headers, headers)
   }
@@ -48,13 +48,13 @@ class ResponseTest: XCTestCase {
                    "WWW-Authenticate" : "Basic realm=\"simple\""]
 
     let rawHeaders = "Content-Type:text/html\r\nWWW-Authenticate:Basic realm=\"simple\""
-    let body = Array("BODY".utf8)
+    let body = "BODY"
     let formattedStatus: [UInt8] = Array("HTTP/1.1 200 OK\r\n".utf8)
     let formattedHeaders: [UInt8] = Array(rawHeaders.utf8)
-    let formattedBody: [UInt8] = Array("\n\n".utf8) + body
+    let formattedBody: [UInt8] = Array("\n\n\(body)".utf8)
     let formattedResponse = formattedStatus + formattedHeaders + formattedBody
 
-    let response = Response(status: ok, headers: headers, body: body)
+    let response = HTTPResponse(status: ok, headers: headers, body: body)
 
     XCTAssertEqual(response.formatted, formattedResponse)
   }


### PR DESCRIPTION
- rename Response class to HTTPResponse
- implement Response protocol with multiple inits
- remove getBase64 Util function for hard-coded base64 encoded credentials
- pass implicitly unwrapped range Request header into PartialContentsController as arg.