### PR TITLE
Params Protocol:

### DIFF
--- a/Sources/Controllers/CookieController.swift
+++ b/Sources/Controllers/CookieController.swift
@@ -10,7 +10,7 @@ public class CookieController: Controller {
     if let params = request.params {
       body = "Eat"
 
-      headers["Set-Cookie"] = params.toString()
+      String(parameters: params).map { headers["Set-Cookie"] = $0 }
     }
 
     if let cookie = request.headers["cookie"] {

--- a/Sources/Requests/HTTPParameters.swift
+++ b/Sources/Requests/HTTPParameters.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public class HTTPParameters: Params {
+  public let rawParams: String
+  public let keyValueSeparator: String = "="
+  public let multipleSeparator: String = "&"
+  public var keys: [String] = []
+  public var values: [String] = []
+
+  public init(for rawParams: String) {
+    self.rawParams = rawParams
+
+    let flattenedParams = rawParams.components(separatedBy: multipleSeparator)
+                                   .flatMap { $0.components(separatedBy: keyValueSeparator) }
+                                   .filter { !$0.isEmpty }
+
+    for (index, param) in flattenedParams.enumerated() {
+      if index == flattenedParams.count - 1 && flattenedParams.count % 2 != 0 {
+        break
+      }
+
+      if index % 2 == 0 {
+        keys.append(decode(param))
+      }
+      else {
+        values.append(decode(param))
+      }
+    }
+  }
+
+  public func toDictionary() -> [String: String] {
+    var matchedParams: [String: String] = [:]
+
+    if keys.isEmpty && values.isEmpty {
+      return matchedParams
+    }
+
+    for (index, key) in keys.enumerated() {
+      matchedParams[key] = values[index]
+    }
+
+    return matchedParams
+  }
+
+  private func decode(_ rawParams: String) -> String {
+    return rawParams.removingPercentEncoding ?? rawParams
+  }
+
+}

--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -8,6 +8,7 @@ public struct HTTPRequest: Request {
   public let body: String?
   public let crlf: String = "\r\n"
   public let parameterDivide: String = "?"
+  public let parameterKeyValueSeparator: String = "="
 
   public var headers: [String: String] = [:]
 
@@ -26,7 +27,16 @@ public struct HTTPRequest: Request {
     path = parsedPath.first ?? fullPath
     pathName = path.substring(from: path.index(after: path.startIndex))
 
-    params = parsedPath.index(where: { $0.contains("=") }).map { _ in Params(for: fullPath) }
+    let separator = parameterKeyValueSeparator
+
+    params = parsedPath.index(where: { $0.contains(separator) }).flatMap { index -> HTTPParameters? in
+      let dividedParams = parsedPath[index].components(separatedBy: separator).filter { !$0.isEmpty }
+      if dividedParams.count < 2 {
+        return nil
+      }
+
+      return HTTPParameters(for: parsedPath[index])
+    }
 
     let requestTail = parsedRequest[parsedRequest.index(before: parsedRequest.endIndex)]
 

--- a/Sources/Requests/Params.swift
+++ b/Sources/Requests/Params.swift
@@ -1,46 +1,30 @@
-import Foundation
+public protocol Params {
+  var keyValueSeparator: String { get }
+  var multipleSeparator: String { get }
+  var keys: [String] { get }
+  var values: [String] { get }
 
-public class Params {
-  public let path: String
+  func toDictionary() -> [String: String]
+}
 
-  public init(for path: String) {
-    self.path = path
-  }
 
-  public func toString() -> String {
-    let formattedParams = getParams().replacingOccurrences(of: "&", with: "\n")
+public protocol Parameterizable {
+  init?(parameters: Params)
+}
 
-    return decode(formattedParams)
-  }
 
-  public func toDictionary() -> [String: String] {
-    var matchedParams: [String: String] = [:]
+extension String: Parameterizable {
+  public init?(parameters: Params) {
+    var result = ""
 
-    for (index, paramKey) in keys().enumerated() {
-      matchedParams[paramKey] = values()[index]
+    if parameters.keys.isEmpty && parameters.values.isEmpty {
+      return nil
     }
 
-    return matchedParams
-  }
-
-  public func keys() -> [String] {
-    return getParams().components(separatedBy: "&").map {
-      decode($0.components(separatedBy: "=").first ?? "")
+    for (index, paramKey) in parameters.keys.enumerated() {
+      result += (paramKey + parameters.keyValueSeparator + parameters.values[index] + "\n")
     }
-  }
 
-  public func values() -> [String] {
-    return getParams().components(separatedBy: "&").map {
-      decode($0.components(separatedBy: "=").last ?? "")
-    }
+    self.init(result.trimmingCharacters(in: .newlines))
   }
-
-  private func getParams() -> String {
-    return path.components(separatedBy: "?").last ?? ""
-  }
-
-  private func decode(_ rawParams: String) -> String {
-    return rawParams.removingPercentEncoding ?? rawParams
-  }
-
 }

--- a/Tests/RequestsTests/ParamsTest.swift
+++ b/Tests/RequestsTests/ParamsTest.swift
@@ -3,157 +3,203 @@ import XCTest
 
 class ParamsTest: XCTestCase {
   func testItCanBeAString() {
-    let fullPath = "/some_path?my=params"
+    let fullPath = "my=params"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.toString(), "my=params")
+    XCTAssertEqual(String(parameters: params)!, "my=params")
   }
 
   func testItCanBeADynamicString() {
-    let fullPath = "/some_path?type=oatmeal"
+    let fullPath = "type=oatmeal"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.toString(), "type=oatmeal")
+    XCTAssertEqual(String(parameters: params)!, "type=oatmeal")
   }
 
   func testItHasKeys() {
-    let fullPath = "/some_path?type=oatmeal"
+    let fullPath = "type=oatmeal"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys(), ["type"])
+    XCTAssertEqual(params.keys, ["type"])
   }
 
   func testItHasDynamicKeys() {
-    let fullPath = "/some_path?my=params"
+    let fullPath = "my=params"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys(), ["my"])
+    XCTAssertEqual(params.keys, ["my"])
   }
 
   func testItHasValues() {
-    let fullPath = "/some_path?type=oatmeal"
+    let fullPath = "type=oatmeal"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.values(), ["oatmeal"])
+    XCTAssertEqual(params.values, ["oatmeal"])
   }
 
   func testItHasDynamicValues() {
-    let fullPath = "/some_path?type=chocolate"
+    let fullPath = "type=chocolate"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.values(), ["chocolate"])
+    XCTAssertEqual(params.values, ["chocolate"])
   }
 
   func testItCanHandleBlankParamsToString() {
-    let fullPath = "/some_path?type="
+    let fullPath = "type="
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.toString(), "type=")
+    XCTAssertNil(String(parameters: params))
+  }
+
+  func testItCanHandleNestedBlankParamValuesToString() {
+    let fullPath = "type=chocolate&wow="
+
+    let params = HTTPParameters(for: fullPath)
+
+    XCTAssertEqual(String(parameters: params)!, "type=chocolate")
+  }
+
+  func testItCanHandleNestedBlankParamKeysToString() {
+    let fullPath = "type=chocolate&=wow"
+
+    let params = HTTPParameters(for: fullPath)
+
+    XCTAssertEqual(String(parameters: params)!, "type=chocolate")
   }
 
   func testItCanHandleBlankParamsKeys() {
-    let fullPath = "/some_path?type="
+    let fullPath = "=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys(), ["type"])
+    XCTAssertEqual(params.keys, [])
   }
 
   func testItCanHandleBlankParamsValues() {
-    let fullPath = "/some_path?type="
+    let fullPath = "type="
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.values(), [""])
+    XCTAssertEqual(params.values, [])
+  }
+
+  func testItCanHandleInvalidParamsToDictionary() {
+    let fullPath = "type="
+
+    let params = HTTPParameters(for: fullPath)
+
+    XCTAssertEqual(params.toDictionary(), [:])
+  }
+
+  func testItCanHandleNestedInvalidParamsToDict() {
+    let path = "type=chocolate&stuff="
+    let params = HTTPParameters(for: path)
+
+    XCTAssertEqual(params.toDictionary(), ["type": "chocolate"])
+  }
+
+  func testItCanHandleNestedInvalidParamsKeys() {
+    let path = "type=chocolate&stuff="
+    let params = HTTPParameters(for: path)
+
+    XCTAssertEqual(params.keys, ["type"])
+  }
+
+  func testItCanHandleNestedInvalidParamsVals() {
+    let path = "type=chocolate&=stuff"
+    let params = HTTPParameters(for: path)
+
+    XCTAssertEqual(params.values, ["chocolate"])
   }
 
   func testItCanConvertToDictionary() {
-    let fullPath = "/some_path?type=oatmeal"
+    let fullPath = "type=oatmeal"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
     XCTAssertEqual(params.toDictionary(), ["type": "oatmeal"])
   }
 
   func testItCanDynamicallyConvertToDictionary() {
-    let fullPath = "/some_path?my=params"
+    let fullPath = "my=params"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
     XCTAssertEqual(params.toDictionary(), ["my": "params"])
   }
 
   func testItCanHandleMultipleParamsToString() {
-    let fullPath = "/some_path?my=params&cool=stuff"
+    let fullPath = "my=params&cool=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.toString(), "my=params\ncool=stuff")
+    XCTAssertEqual(String(parameters: params)!, "my=params\ncool=stuff")
   }
 
   func testItCanHandleMultipleParamsKeys() {
-    let fullPath = "/some_path?my=params&cool=stuff"
+    let fullPath = "my=params&cool=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys(), ["my", "cool"])
+    XCTAssertEqual(params.keys, ["my", "cool"])
   }
 
   func testItCanHandleMultipleParamsVals() {
-    let fullPath = "/some_path?my=params&cool=stuff"
+    let fullPath = "my=params&cool=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.values(), ["params", "stuff"])
+    XCTAssertEqual(params.values, ["params", "stuff"])
   }
 
   func testItCanHandleMultipleParamsToDict() {
-    let fullPath = "/some_path?my=params&cool=stuff"
+    let fullPath = "my=params&cool=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
     XCTAssertEqual(params.toDictionary(), ["my": "params", "cool": "stuff"])
   }
 
   func testItCanHandleEncodedParamsToString() {
-    let fullPath = "/parameters?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
+    let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
     let expected = "variable_1=Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2=stuff"
 
-    XCTAssertEqual(params.toString(), expected)
+    XCTAssertEqual(String(parameters: params)!, expected)
   }
 
   func testItCanHandleEncodedParamsKeys() {
-    let fullPath = "/parameters?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D&variable_2=stuff"
+    let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D&variable_2=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys(), ["variable_1", "variable_2"])
+    XCTAssertEqual(params.keys, ["variable_1", "variable_2"])
   }
 
   func testItCanHandleEncodedParamsVals() {
-    let fullPath = "/parameters?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
+    let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
     let expected = ["Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "stuff"]
 
-    XCTAssertEqual(params.values(), expected)
+    XCTAssertEqual(params.values, expected)
   }
 
   func testItCanHandleEncodedParamsToDict() {
-    let fullPath = "/parameters?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
+    let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = Params(for: fullPath)
+    let params = HTTPParameters(for: fullPath)
     let expected = ["variable_1": "Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "variable_2": "stuff"]
 
     XCTAssertEqual(params.toDictionary(), expected)
   }
+
 }

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -84,18 +84,18 @@ class RequestTest: XCTestCase {
         XCTAssertNil(request.params)
     }
 
-    func testItCanRecognizeBlankParamVals() {
+    func testItDoesntCreateParamsWithBlankValues() {
         let rawRequest = "GET /cookie?sometihgnaksjnd= HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
         let request = HTTPRequest(for: rawRequest)
 
-        XCTAssertEqual(request.params!.toDictionary(), ["sometihgnaksjnd": ""])
+        XCTAssertNil(request.params)
     }
 
     func testItCanRecognizeBlankParamKey() {
         let rawRequest = "GET /cookie?=sometihgnaksjnd HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
         let request = HTTPRequest(for: rawRequest)
 
-        XCTAssertEqual(request.params!.toDictionary(), ["": "sometihgnaksjnd"])
+        XCTAssertNil(request.params)
     }
 
     func testItHasParams() {


### PR DESCRIPTION
- Parameterizable protocol extended to String,
- Rename struct to HTTPParameters
- remove toString() method from HTTPParameters,
- Keys and Values are stored properties instead of functions,
- Params to reject any invalid key value types and keep valid ones,
- Request to return nil for Params optional if initial key value pair is invalid.
- params to only take k/v pairs as string instead of full path