### PR TITLE
Close #81: Router Unit Testing:

### DIFF
--- a/Sources/Router/OperationQueue+ThreadQueue.swift
+++ b/Sources/Router/OperationQueue+ThreadQueue.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension OperationQueue: ThreadQueue {
+
+  public func add(operation: RespondOperation) {
+    self.addOperation(operation)
+  }
+
+}

--- a/Sources/Router/RespondOperation.swift
+++ b/Sources/Router/RespondOperation.swift
@@ -4,35 +4,35 @@ import Responses
 import Foundation
 import Util
 
-class RespondOperation: Operation {
-  override var isAsynchronous: Bool {
+public class RespondOperation: Operation {
+  public override var isAsynchronous: Bool {
     return true
   }
 
-  override var isConcurrent: Bool {
+  public override var isConcurrent: Bool {
     return true
   }
 
-  override var isExecuting: Bool {
+  public override var isExecuting: Bool {
     return currentlyExecuting
   }
 
-  override var isFinished: Bool {
+  public override var isFinished: Bool {
     return currentlyFinished
   }
 
-  var currentlyExecuting: Bool = false
-  var currentlyFinished: Bool = false
+  private var currentlyExecuting: Bool = false
+  private var currentlyFinished: Bool = false
 
-  let response: Response
-  let client: Socket
+  private let response: Response
+  private let client: Socket
 
-  init(response: Response, client: Socket) {
+  public init(response: Response, client: Socket) {
     self.response = response
     self.client = client
   }
 
-  override func start() {
+  public override func start() {
     do {
       currentlyExecuting = true
 

--- a/Sources/Router/Router.swift
+++ b/Sources/Router/Router.swift
@@ -1,60 +1,48 @@
-import SocksCore
-import Foundation
 import Requests
 import Responses
 import Controllers
 import Util
-import Shared
-import FileIO
 
 public class Router {
+  let port: UInt16
+  let socket: Socket
+  let persistedData: ControllerData
+  let threadQueue: ThreadQueue
 
-  public init() {}
+  public init(socket: Socket, data: ControllerData, threadQueue: ThreadQueue, port: UInt16) {
+    self.port = port
+    self.socket = socket
+    self.persistedData = data
+    self.threadQueue = threadQueue
+  }
 
-  public func listen(port: UInt16) throws {
-    let fileManager = FileManager.default
-    let address = InternetAddress.localhost(port: port)
-    let socket = try TCPInternetSocket(address: address)
-
+  public func listen() throws {
     try socket.bind()
     try socket.listen()
+  }
 
-    let publicDir = try CommandLineReader().publicDirectoryArgs() ?? ""
-    let fileNames = try FileReader(fileManager).getFileNames(at: publicDir)
-    var contents: [String: Data] = [:]
+  public func receive() throws {
+    let client = try socket.acceptSocket()
+    let data = try client.recv()
 
-    for file in fileNames {
-      contents[file] = try Data(contentsOf: URL(fileURLWithPath: publicDir + "/" + file))
+    if !data.isEmpty {
+      let request = try HTTPRequest(for: data.toString())
+      try dispatch(request, client: client)
     }
 
-    let persistedData = ControllerData(contents)
-
-    persistedData.addNew(key: "form", value: "")
-    persistedData.addNew(key: "logs", value: "")
-    persistedData.addNew(key: "cookie", value: "")
-
-    print("Listening on \"\(address.hostname)\" (\(address.addressFamily)) \(address.port)")
-
-    let opQueue: OperationQueue = OperationQueue()
-
-    while true {
-      let client = try socket.accept()
-      let data = try client.recv()
-
-      if !data.isEmpty {
-        let request = try HTTPRequest(for: data.toString())
-        let controller = ControllerFactory.getController(request, with: persistedData)
-
-        let response = controller.process(request)
-
-        let newOperation = RespondOperation(response: response, client: client)
-
-        opQueue.addOperation(newOperation)
-      }
-
-      if opQueue.operationCount == opQueue.maxConcurrentOperationCount {
-        opQueue.waitUntilAllOperationsAreFinished()
-      }
+    if threadQueue.operationCount == threadQueue.maxConcurrentOperationCount {
+      threadQueue.waitUntilAllOperationsAreFinished()
     }
   }
+
+  private func dispatch(_ request: Request, client: Socket) throws {
+    let controller = ControllerFactory.getController(request, with: persistedData)
+
+    let response = controller.process(request)
+
+    let newOperation = RespondOperation(response: response, client: client)
+
+    threadQueue.add(operation: newOperation)
+  }
+
 }

--- a/Sources/Router/Socket.swift
+++ b/Sources/Router/Socket.swift
@@ -1,5 +1,13 @@
 public protocol Socket {
+  func bind() throws
+
+  func listen() throws
+
+  func acceptSocket() throws -> Socket
+
   func send(data: [UInt8]) throws
+
+  func recv() throws -> [UInt8]
 
   func close() throws
 }

--- a/Sources/Router/TCPInternetSocket+Socket.swift
+++ b/Sources/Router/TCPInternetSocket+Socket.swift
@@ -1,3 +1,17 @@
 import SocksCore
 
-extension TCPInternetSocket: Socket {}
+extension TCPInternetSocket: Socket {
+
+  public func recv() throws -> [UInt8] {
+    return try self.recv(maxBytes: 65_507)
+  }
+
+  public func listen() throws {
+    return try self.listen(queueLimit: 4096)
+  }
+
+  public func acceptSocket() throws -> Socket {
+    return try self.accept()
+  }
+
+}

--- a/Sources/Router/ThreadQueue.swift
+++ b/Sources/Router/ThreadQueue.swift
@@ -1,0 +1,8 @@
+public protocol ThreadQueue {
+  var operationCount: Int { get }
+  var maxConcurrentOperationCount: Int { get }
+
+  func add(operation: RespondOperation)
+
+  func waitUntilAllOperationsAreFinished()
+}

--- a/Sources/Server/main.swift
+++ b/Sources/Server/main.swift
@@ -1,23 +1,42 @@
 import Foundation
+import SocksCore
 import Router
 import Util
 import Errors
 import Shared
 import FileIO
 
+let defaultPort: UInt16 = 5000
 let reader = CommandLineReader()
+var contents: [String: Data] = [:]
 
 do {
-  let defaultPort: UInt16 = 5000
-  let givenPort = try reader.portArgs()
+  let port = try reader.portArgs() ?? defaultPort
 
-  try Router().listen(port: givenPort ?? defaultPort)
+  let address = InternetAddress.localhost(port: port)
+  let socket = try TCPInternetSocket(address: address)
+
+  let publicDir = try reader.publicDirectoryArgs() ?? ""
+  let fileNames = try FileReader(FileManager.default).getFileNames(at: publicDir)
+
+  for file in fileNames {
+    contents[file] = try Data(contentsOf: URL(fileURLWithPath: publicDir + "/" + file))
+  }
+
+  let persistedData = ControllerData(contents, nonFiles: ["form", "logs", "cookie"])
+
+  let router = Router(socket: socket, data: persistedData, threadQueue: OperationQueue(), port: port)
+
+  try router.listen()
+
+  while true {
+    try router.receive()
+  }
 } catch {
   let fileName = formatTimestamp(prefix: "FAILURE")
   let urlPath = URL(fileURLWithPath: logsPath + fileName).appendingPathExtension("txt")
   try FileWriter<URL>(at: urlPath, with: "ERROR: \(error)\r\nARGS: \(reader.joinedArgs)")
                      .write()
 
-  print(" ‼️  :", error)
   throw error
 }

--- a/Sources/Util/ControllerData.swift
+++ b/Sources/Util/ControllerData.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-public extension Data {
-  init(value: String) {
-    self.init(bytes: Array(value.utf8))
-  }
-}
-
 public class ControllerData {
-  public var contents: [String: Data]
+  private var contents: [String: Data]
+  private let nonFiles: [String]
 
-  public init(_ contents: [String: Data]) {
+  public init(_ fileContents: [String: Data], nonFiles: [String] = []) {
+    var contents = fileContents
+
+    nonFiles.forEach {
+      contents[$0] = Data(value: "")
+    }
+
     self.contents = contents
+    self.nonFiles = nonFiles
   }
 
   public func update(_ key: String, withVal value: String) {
@@ -30,7 +32,13 @@ public class ControllerData {
   }
 
   public func fileNames() -> [String] {
-    return contents.keys.filter { $0 != "form" && $0 != "logs" }
+    return contents.keys.filter { !nonFiles.contains($0) }
   }
 
+}
+
+public extension Data {
+  init(value: String) {
+    self.init(bytes: Array(value.utf8))
+  }
 }

--- a/Tests/RouterTests/MockOperationQueue.swift
+++ b/Tests/RouterTests/MockOperationQueue.swift
@@ -1,0 +1,21 @@
+import Router
+
+class MockOperationQueue: ThreadQueue {
+  var operations: [RespondOperation] = []
+  var wasWaitMethodCalled: Bool = false
+
+  var maxConcurrentOperationCount: Int = 0
+
+  var operationCount: Int {
+    return operations.count
+  }
+
+  func add(operation: RespondOperation) {
+    operations.append(operation)
+  }
+
+  func waitUntilAllOperationsAreFinished() {
+    wasWaitMethodCalled = true
+  }
+}
+

--- a/Tests/RouterTests/MockTCPSocket.swift
+++ b/Tests/RouterTests/MockTCPSocket.swift
@@ -1,0 +1,42 @@
+import Router
+
+class MockTCPSocket: Socket {
+  var wasBindCalled: Bool = false
+  var wasListenCalled: Bool = false
+  var wasAcceptCalled: Bool = false
+  var wasRecvCalled: Bool = false
+  var wasSendCalled: Bool = false
+  var wasCloseCalled: Bool = false
+
+  let rawRequest: String?
+
+  init(_ rawRequest: String? = nil) {
+    self.rawRequest = rawRequest
+  }
+
+  func listen() {
+    wasListenCalled = true
+  }
+
+  func recv() throws -> [UInt8] {
+    wasRecvCalled = true
+    return rawRequest.map { Array($0.utf8) } ?? []
+  }
+
+  func bind() throws {
+    wasBindCalled = true
+  }
+
+  func acceptSocket() throws -> Socket {
+    wasAcceptCalled = true
+    return self
+  }
+
+  func send(data: [UInt8]) throws {
+    wasSendCalled = true
+  }
+
+  func close() throws {
+    wasCloseCalled = true
+  }
+}

--- a/Tests/RouterTests/RespondOperationTest.swift
+++ b/Tests/RouterTests/RespondOperationTest.swift
@@ -2,20 +2,6 @@ import XCTest
 @testable import Router
 import Responses
 
-class MockTCPSocket: Socket {
-  var wasSendCalled: Bool = false
-  var wasCloseCalled: Bool = false
-
-  func send(data: [UInt8]) throws {
-    wasSendCalled = true
-  }
-
-  func close() throws {
-    wasCloseCalled = true
-  }
-}
-
-
 class RespondOperationTest: XCTestCase {
   func itDoesNotSendOnInit() {
     let response = HTTPResponse(status: TwoHundred.Ok)

--- a/Tests/RouterTests/RouterTest.swift
+++ b/Tests/RouterTests/RouterTest.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Router
+import FileIO
+import Util
+
+class RouterTest: XCTestCase {
+
+  func testItBindsTheSocket() throws {
+    let port: UInt16 = 5000
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: MockOperationQueue(), port: port)
+
+    try router.listen()
+
+    XCTAssert(mockSock.wasBindCalled)
+  }
+
+  func testItOpensTheSocketToListen() throws {
+    let port: UInt16 = 5000
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: MockOperationQueue(), port: port)
+
+    try router.listen()
+
+    XCTAssert(mockSock.wasBindCalled)
+  }
+
+  func testItAcceptsTheSocket() throws {
+    let port: UInt16 = 5000
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: MockOperationQueue(), port: port)
+
+    try router.receive()
+
+    XCTAssert(mockSock.wasAcceptCalled)
+  }
+
+  func testItReceivesData() throws {
+    let port: UInt16 = 5000
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: MockOperationQueue(), port: port)
+
+    try router.receive()
+
+    XCTAssert(mockSock.wasRecvCalled)
+  }
+
+  func testItAddsAnOperationToResponseQueueIfDataIsNotEmpty() throws {
+    let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
+    let port: UInt16 = 5000
+
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket(rawRequest)
+    let mockQueue = MockOperationQueue()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: mockQueue, port: port)
+
+    try router.receive()
+
+    XCTAssertEqual(mockQueue.operationCount, 1)
+  }
+
+  func testItDoesNotAddAnOperationIfDataIsEmpty() throws {
+    let port: UInt16 = 5000
+
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket()
+    let mockQueue = MockOperationQueue()
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: mockQueue, port: port)
+
+    try router.receive()
+
+    XCTAssertEqual(mockQueue.operationCount, 0)
+  }
+
+  func testItTellsQueueToWaitIfOperationLimitIsHit() throws {
+    let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
+    let port: UInt16 = 5000
+
+    let fileContents = ["file1": Data(value: "I'm a text file")]
+    let controllerData = ControllerData(fileContents)
+    let mockSock = MockTCPSocket(rawRequest)
+    let mockQueue = MockOperationQueue()
+
+    mockQueue.maxConcurrentOperationCount = 1
+
+    let router = Router(socket: mockSock, data: controllerData, threadQueue: mockQueue, port: port)
+
+    try router.receive()
+
+    XCTAssert(mockQueue.wasWaitMethodCalled)
+  }
+
+}

--- a/Tests/UtilTests/ControllerDataTest.swift
+++ b/Tests/UtilTests/ControllerDataTest.swift
@@ -28,4 +28,13 @@ class ControllerDataTest: XCTestCase {
 
     XCTAssertEqual(referenceToData.first!.get("file1"), "I'm a modified text file")
   }
+
+  func testItCanFilterOutGivenFilenames() {
+    let contents: [String: Data] = ["file1": Data(value: "I'm a text file")]
+    let nonFiles = ["logs", "cookie"]
+
+    let data = ControllerData(contents, nonFiles: nonFiles)
+
+    XCTAssertEqual(data.fileNames(), ["file1"])
+  }
 }


### PR DESCRIPTION
  - Router to take Socket, ControllerData, ThreadQueue, and Port on init
  - ThreadQueue protocol extended to OperationQueue
  - Place Mocks in their own files in Tests/RouterTests
  - Loop in Router moved up to main
  - Router#dispatch executes code formerly in loop
  - ControllerData to take optional nonFiles argument
  - main.swift to pass in necessary dependencies.