### PR TITLE
Close #73: CommandLineReader - Unit Testing:

### DIFF
--- a/Sources/Errors/Errors.swift
+++ b/Sources/Errors/Errors.swift
@@ -7,3 +7,20 @@ public enum ServerStartError: Error {
 public enum BadRequestError: Error {
   case InvalidRequest(for: String)
 }
+
+extension ServerStartError: Equatable {
+  public static func ==(lhs: ServerStartError, rhs: ServerStartError) -> Bool {
+    switch (lhs, rhs) {
+    case (.MissingPublicDirectoryArgument, .MissingPublicDirectoryArgument):
+      return true
+    case (.InvalidPublicDirectoryGiven, .InvalidPublicDirectoryGiven):
+      return true
+
+    case (.MissingArgumentFor(flag: let lFlag), .MissingArgumentFor(flag: let rFlag)):
+      return lFlag == rFlag
+
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/Server/main.swift
+++ b/Sources/Server/main.swift
@@ -7,7 +7,7 @@ import Shared
 import FileIO
 
 let defaultPort: UInt16 = 5000
-let reader = CommandLineReader()
+let reader = CommandLineReader(args: CommandLine.arguments)
 var contents: [String: Data] = [:]
 
 do {

--- a/Sources/Util/CommandLineReader.swift
+++ b/Sources/Util/CommandLineReader.swift
@@ -8,18 +8,8 @@ public class CommandLineReader {
     return args.joined(separator: "\r\n")
   }
 
-  public init() {
-    args = CommandLine.arguments
-  }
-
-  public func getArgumentAfter(flag: String) throws -> String? {
-    return try args.index(where: { $0.contains(flag) }).map { flagIndex throws -> String in
-      guard flagIndex != args.count - 1 else {
-        throw ServerStartError.MissingArgumentFor(flag: flag)
-      }
-
-      return args[args.index(after: flagIndex)]
-    }
+  public init(args: [String]) {
+    self.args = args
   }
 
   public func publicDirectoryArgs() throws -> String? {
@@ -28,6 +18,16 @@ public class CommandLineReader {
 
   public func portArgs() throws -> UInt16? {
     return try getArgumentAfter(flag: "-p").flatMap { UInt16($0) }
+  }
+
+  private func getArgumentAfter(flag: String) throws -> String? {
+    return try args.index(where: { $0.contains(flag) }).map { flagIndex throws -> String in
+      guard flagIndex != args.count - 1 else {
+        throw ServerStartError.MissingArgumentFor(flag: flag)
+      }
+
+      return args[args.index(after: flagIndex)]
+    }
   }
 
 }

--- a/Tests/UtilTests/CommandLineReaderTest.swift
+++ b/Tests/UtilTests/CommandLineReaderTest.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Util
+import Errors
+
+class CommandLineReaderTest: XCTestCase {
+  func testItCanGrabPortArgument() {
+    let args = ["/path/to/somewhere", "-p", "5000", "-d", "some/other/path"]
+
+    let reader = CommandLineReader(args: args)
+
+    let port = try! reader.portArgs()
+
+    let expected = UInt16("5000")!
+
+    XCTAssertEqual(port!, expected)
+  }
+
+  func testItCanGrabDirectoryArgument() {
+    let args = ["/path/to/somewhere", "-p", "5000", "-d", "some/other/path"]
+
+    let reader = CommandLineReader(args: args)
+
+    let publicDir = try! reader.publicDirectoryArgs()
+
+    XCTAssertEqual(publicDir!, "some/other/path")
+  }
+
+  func testItCanThrowIfDirectoryArgumentIsInaccessible() {
+    let args = ["/path/to/somewhere", "-p", "5000", "-d"]
+
+    let reader = CommandLineReader(args: args)
+
+    XCTAssertThrowsError(try reader.publicDirectoryArgs()) { error in
+      XCTAssertEqual(error as! ServerStartError, ServerStartError.MissingArgumentFor(flag: "-d"))
+    }
+  }
+
+  func testItCanThrowIfPortArgumentIsInaccessible() {
+    let args = ["/path/to/somewhere", "5000", "-d", "-p"]
+
+    let reader = CommandLineReader(args: args)
+
+    XCTAssertThrowsError(try reader.portArgs()) { error in
+      XCTAssertEqual(error as! ServerStartError, ServerStartError.MissingArgumentFor(flag: "-p"))
+    }
+  }
+}


### PR DESCRIPTION
  - Inject CommandLine arguments to CommandLineReader on init
  - Test error handling and getting of port and directory arguments
  - getArgumentAfter(flag:) fn now private