### PR TITLE
Close #75: FileReader Error Handling Unit Test:

### DIFF
--- a/Tests/FileIOTests/FileReaderTest.swift
+++ b/Tests/FileIOTests/FileReaderTest.swift
@@ -1,11 +1,6 @@
 import XCTest
 @testable import FileIO
-
-class MockFileManager: FileIO {
-  func contentsOfDirectory(atPath path: String) throws -> [String] {
-    return ["file1", "file2"]
-  }
-}
+import Errors
 
 class FileReaderTest: XCTestCase {
   func testItCanReadFileNames() {
@@ -19,7 +14,14 @@ class FileReaderTest: XCTestCase {
     XCTAssertEqual(result, ["file1", "file2"])
   }
 
-  func testItCanThrow() {
-    // implement me!
+  func testItThrowsIfPathIsNotCobSpecPath() throws {
+    let path = "/some/random/path"
+    let fileManager = MockFileManager()
+
+    let fileReader = FileReader(fileManager)
+
+    XCTAssertThrowsError(try fileReader.getFileNames(at: path)) { error in
+      XCTAssertEqual(error as! ServerStartError, ServerStartError.InvalidPublicDirectoryGiven)
+    }
   }
 }

--- a/Tests/FileIOTests/FileWriterTest.swift
+++ b/Tests/FileIOTests/FileWriterTest.swift
@@ -1,16 +1,6 @@
 import XCTest
 @testable import FileIO
 
-class MockContent: Writable {
-  var didWrite: Bool = false
-  var givenArgs: URL = URL(fileURLWithPath: "")
-
-  func write<WriteableLocation>(to destination: WriteableLocation) throws {
-    didWrite = true
-    givenArgs = destination as! URL
-  }
-}
-
 class FileWriterTest: XCTestCase {
   func testInitDoesNotCallWritableWriteMethod() {
     let path = "/some/path/to/somewhere"

--- a/Tests/FileIOTests/MockContent.swift
+++ b/Tests/FileIOTests/MockContent.swift
@@ -1,0 +1,13 @@
+import FileIO
+import Foundation
+
+class MockContent: Writable {
+  var didWrite: Bool = false
+  var givenArgs: URL = URL(fileURLWithPath: "")
+
+  func write<WriteableLocation>(to destination: WriteableLocation) throws {
+    didWrite = true
+    givenArgs = destination as! URL
+  }
+}
+

--- a/Tests/FileIOTests/MockFileManager.swift
+++ b/Tests/FileIOTests/MockFileManager.swift
@@ -1,0 +1,7 @@
+import FileIO
+
+class MockFileManager: FileIO {
+  func contentsOfDirectory(atPath path: String) throws -> [String] {
+    return ["file1", "file2"]
+  }
+}


### PR DESCRIPTION
  - Test ServerStartError
  - Move FileIO mocks into separate files.