### PR TITLE
Close #94: DateHelper unit test

### DIFF
--- a/Sources/Server/main.swift
+++ b/Sources/Server/main.swift
@@ -33,7 +33,7 @@ do {
     try router.receive()
   }
 } catch {
-  let fileName = formatTimestamp(prefix: "FAILURE")
+  let fileName = DateHelper(today: Date(), calendar: Calendar.current, formatter: DateFormatter()).formatTimestamp(prefix: "FAILURE")
   let urlPath = URL(fileURLWithPath: logsPath + fileName).appendingPathExtension("txt")
   try FileWriter<URL>(at: urlPath, with: "ERROR: \(error)\r\nARGS: \(reader.joinedArgs)")
                      .write()

--- a/Sources/Util/Calendar+Calendarizable.swift
+++ b/Sources/Util/Calendar+Calendarizable.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Calendar: Calendarizable {
+  public func currentHour(from today: Date) -> Int {
+    return self.component(.hour, from: today)
+  }
+
+  public func currentMinute(from today: Date) -> Int {
+    return self.component(.minute, from: today)
+  }
+
+  public func currentSecond(from today: Date) -> Int {
+    return self.component(.second, from: today)
+  }
+}

--- a/Sources/Util/Calendarizable.swift
+++ b/Sources/Util/Calendarizable.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol Calendarizable {
+  func currentHour(from today: Date) -> Int
+  func currentMinute(from today: Date) -> Int
+  func currentSecond(from today: Date) -> Int
+}

--- a/Sources/Util/DateFormattable.swift
+++ b/Sources/Util/DateFormattable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol DateFormattable {
+  var dateFormat: String! { get set }
+  func string(from today: Date) -> String
+}

--- a/Sources/Util/DateFormatter+DateFormattable.swift
+++ b/Sources/Util/DateFormatter+DateFormattable.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension DateFormatter: DateFormattable {}

--- a/Sources/Util/DateHelper.swift
+++ b/Sources/Util/DateHelper.swift
@@ -1,21 +1,32 @@
 import Foundation
 
 public class DateHelper {
-  private let today = Date()
-  private let calendar = Calendar.current
-  private let formatter = DateFormatter()
+  private let today: Date
+  private let calendar: Calendarizable
+  private var formatter: DateFormattable
 
-  public init() {}
+  public init(today: Date, calendar: Calendarizable, formatter: DateFormattable) {
+    self.today = today
+    self.calendar = calendar
+    self.formatter = formatter
+  }
 
-  public func time(separator: String) -> String {
-    let hour = calendar.component(.hour, from: today)
-    let minutes = calendar.component(.minute, from: today)
-    let seconds = calendar.component(.second, from: today)
+  public func formatTimestamp(prefix: String, dateSeparator: String = "-") -> String {
+    let currentTime = time(separator: ":")
+    let today = date(separator: dateSeparator)
+
+    return "\(prefix)-\(currentTime)--\(today)"
+  }
+
+  private func time(separator: String) -> String {
+    let hour = calendar.currentHour(from: today)
+    let minutes = calendar.currentMinute(from: today)
+    let seconds = calendar.currentSecond(from: today)
 
     return "\(hour)" + separator + "\(minutes)" + separator + "\(seconds)"
   }
 
-  public func date(separator: String) -> String {
+  private func date(separator: String) -> String {
     formatter.dateFormat = "MM\(separator)dd\(separator)yyyy"
 
     return formatter.string(from: today)

--- a/Sources/Util/Util.swift
+++ b/Sources/Util/Util.swift
@@ -1,14 +1,6 @@
 import Foundation
 import Errors
 
-public func formatTimestamp(prefix: String) -> String {
-  let dateHelper = DateHelper()
-  let currentTime = dateHelper.time(separator: ":")
-  let today = dateHelper.date(separator: "-")
-
-  return "\(prefix)-\(currentTime)--\(today)"
-}
-
 public func isAnImage(_ file: String) -> Bool {
   return file.hasSuffix("jpeg") ||
           file.hasSuffix("gif") ||

--- a/Tests/UtilTests/DateHelperTests.swift
+++ b/Tests/UtilTests/DateHelperTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import Foundation
+@testable import Util
+
+class MockCalendar: Calendarizable {
+  func currentHour(from today: Date) -> Int { return 8 }
+
+  func currentMinute(from today: Date) -> Int { return 45 }
+
+  func currentSecond(from today: Date) -> Int { return 30 }
+}
+
+class MockFormatter: DateFormattable {
+  var dateFormat: String! = "mm/dd/yyyy"
+
+  func string(from today: Date) -> String {
+    return "04/10/2017"
+  }
+}
+
+class DateHelperTest: XCTestCase {
+  func testItFormatsATimestamp() {
+    let dateHelper = DateHelper(today: Date(), calendar: MockCalendar(), formatter: MockFormatter())
+
+    let timestamp = dateHelper.formatTimestamp(prefix: "TEST", dateSeparator: "/")
+    let expected = "TEST-8:45:30--04/10/2017"
+
+    XCTAssertEqual(timestamp, expected)
+  }
+}


### PR DESCRIPTION
 - Calendarizable & DateFormattable protocols,
- extend Foundation's Calendar to Calendarizable protocol
- extend Foundation's DateFormatter to DateFormattable protocol
- create Mocks for above protocols and unit test DateHelper.