### PR TITLE
Close #96: ResourcesController unit test edge cases:

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,10 @@ let package = Package(
       Target(name: "Util", dependencies: [
         .Target(name: "Errors"),
         .Target(name: "Shared")
+      ]),
+      Target(name: "FileIO", dependencies: [
+        .Target(name: "Shared"),
+        .Target(name: "Errors")
       ])
     ],
     dependencies: [

--- a/Tests/ControllersTests/ResourcesControllerTest.swift
+++ b/Tests/ControllersTests/ResourcesControllerTest.swift
@@ -188,4 +188,16 @@ class ResourcesControllerTest: XCTestCase {
 
     XCTAssertEqual(response.body!, expected)
   }
+
+  func testItCanHandlePartialContentRequests() {
+    let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate\r\nRange:bytes=4-"
+    let request = HTTPRequest(for: rawRequest)
+
+    let partialContent = "This is a file that contains text to read part of in order to fulfill a 206."
+    let contents = ControllerData(["partial_content.txt": Data(value: partialContent)])
+
+    let response = ResourcesController(contents: contents).process(request)
+
+    XCTAssertEqual(response.statusCode, "206 Partial Content")
+  }
 }


### PR DESCRIPTION
  - delegation for /partial_content request in ResourcesControllerTest
  - missing internal dependencies to Package.swift.