### PR TITLE
Close #98: CommandLine Reader coverage

### DIFF
--- a/Sources/Server/main.swift
+++ b/Sources/Server/main.swift
@@ -35,7 +35,7 @@ do {
 } catch {
   let fileName = DateHelper(today: Date(), calendar: Calendar.current, formatter: DateFormatter()).formatTimestamp(prefix: "FAILURE")
   let urlPath = URL(fileURLWithPath: logsPath + fileName).appendingPathExtension("txt")
-  try FileWriter<URL>(at: urlPath, with: "ERROR: \(error)\r\nARGS: \(reader.joinedArgs)")
+  try FileWriter<URL>(at: urlPath, with: "ERROR: \(error)\r\nARGS: \(reader.join("\r\n"))")
                      .write()
 
   throw error

--- a/Sources/Util/CommandLineReader.swift
+++ b/Sources/Util/CommandLineReader.swift
@@ -4,12 +4,12 @@ import Errors
 public class CommandLineReader {
   private let args: [String]
 
-  public var joinedArgs: String {
-    return args.joined(separator: "\r\n")
-  }
-
   public init(args: [String]) {
     self.args = args
+  }
+
+  public func join(_ separator: String) -> String {
+    return args.joined(separator: separator)
   }
 
   public func publicDirectoryArgs() throws -> String? {

--- a/Tests/UtilTests/CommandLineReaderTest.swift
+++ b/Tests/UtilTests/CommandLineReaderTest.swift
@@ -3,6 +3,16 @@ import XCTest
 import Errors
 
 class CommandLineReaderTest: XCTestCase {
+  func testItCanJoinArgs() {
+    let args = ["/path/to/somewhere", "-p", "5000"]
+
+    let reader = CommandLineReader(args: args)
+
+    let expected = "/path/to/somewhere\r\n-p\r\n5000"
+
+    XCTAssertEqual(reader.join("\r\n"), expected)
+  }
+
   func testItCanGrabPortArgument() {
     let args = ["/path/to/somewhere", "-p", "5000", "-d", "some/other/path"]
 


### PR DESCRIPTION
 - CommandLineReader#joinedArgs stored prop is now #join func that takes separator
 - test support for join function.