### PR TITLE
Close #101: Router full test coverage

### DIFF
--- a/Tests/RouterTests/MockOperationQueue.swift
+++ b/Tests/RouterTests/MockOperationQueue.swift
@@ -5,6 +5,7 @@ class MockOperationQueue: ThreadQueue {
 
   func async(_ closure: @escaping () throws -> Void) {
     wasAsyncMethodCalled = true
+    try! closure()
   }
 
 }


### PR DESCRIPTION
- break Router#dispatch function into smaller functions
- #dispatch fn only takes a callback to pass to threadQueue.async fn
- #getDispatchCallback to return the callback expected by #dispatch