### PR TITLE
Close #127: Remove newlines from HTTPResponse body

### DIFF
--- a/Sources/Responses/HTTPResponse.swift
+++ b/Sources/Responses/HTTPResponse.swift
@@ -10,18 +10,15 @@ public struct HTTPResponse {
   public init(status: HTTPStatusCode, headers: [String: String] = [:], body: BytesRepresentable? = nil) {
     self.statusCode = status.description
     self.headers = headers
-
-    let divide = bodyDivide
-    self.body = body.map { divide.toBytes + $0.toBytes }
+    self.body = body?.toBytes
   }
 
   public mutating func appendToBody(_ newContent: BytesRepresentable) {
-    let formattedContent = "\n\n".toBytes + newContent.toBytes
-    self.body = body.map { $0 + formattedContent } ?? formattedContent
+    self.body = body.map { $0 + "\n\n".toBytes + newContent.toBytes } ?? newContent.toBytes
   }
 
   public mutating func replaceBody(with newContent: BytesRepresentable) {
-    self.body = "\n\n".toBytes + newContent.toBytes
+    self.body = newContent.toBytes
   }
 
   public mutating func appendToHeaders(with newHeaders: [String: String]) {
@@ -37,7 +34,7 @@ public struct HTTPResponse {
   public var formatted: [UInt8] {
     let joinedHeaders = headers.map { $0 + headerDivide + $1 }.joined(separator: crlf)
     let statusLine = "\(transferProtocol) \(statusCode + crlf)"
-    let formattedBody = body ?? []
+    let formattedBody = body.map { "\n\n".toBytes + $0 } ?? []
 
     return statusLine.toBytes + joinedHeaders.toBytes + formattedBody
   }

--- a/Tests/RespondersTests/RouteResponderTest.swift
+++ b/Tests/RespondersTests/RouteResponderTest.swift
@@ -78,7 +78,7 @@ class RouteResponderTest: XCTestCase {
 
       let newResponse = RouteResponder(routes: routes).getResponse(to: request)
 
-      let expected = "\n\nEat".toBytes
+      let expected = "Eat".toBytes
 
       XCTAssertEqual(newResponse.body!, expected)
     }
@@ -106,7 +106,7 @@ class RouteResponderTest: XCTestCase {
       let responder = RouteResponder(routes: routes)
 
       let response = responder.getResponse(to: request)
-      let result = "\n\nmmmm chocolate".toBytes
+      let result = "mmmm chocolate".toBytes
 
       XCTAssertEqual(response.body!, result)
     }
@@ -133,7 +133,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/someRoute": route]
 
       let res = RouteResponder(routes: routes).getResponse(to: request)
-      let expected = "\n\nGET /someRoute HTTP/1.1".toBytes
+      let expected = "GET /someRoute HTTP/1.1".toBytes
 
       XCTAssertEqual(res.body!, expected)
     }
@@ -149,7 +149,7 @@ class RouteResponderTest: XCTestCase {
 
       let _ = responder.getResponse(to: request)
       let response = responder.getResponse(to: request)
-      let expected = "\n\nGET /someRoute HTTP/1.1\nGET /someRoute HTTP/1.1".toBytes
+      let expected = "GET /someRoute HTTP/1.1\nGET /someRoute HTTP/1.1".toBytes
 
       XCTAssertEqual(response.body!, expected)
     }
@@ -163,7 +163,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/cookie": route]
 
       let res = RouteResponder(routes: routes).getResponse(to: request)
-      let expected = "\n\nEat\n\nGET /cookie HTTP/1.1".toBytes
+      let expected = "Eat\n\nGET /cookie HTTP/1.1".toBytes
 
       XCTAssertEqual(res.body!, expected)
     }
@@ -176,7 +176,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/eat_cookie": route]
 
       let res = RouteResponder(routes: routes).getResponse(to: request)
-      let expected = "\n\nmmmm chocolate\n\nGET /eat_cookie HTTP/1.1".toBytes
+      let expected = "mmmm chocolate\n\nGET /eat_cookie HTTP/1.1".toBytes
 
       XCTAssertEqual(res.body!, expected)
     }
@@ -189,7 +189,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/eat_cookie": route]
 
       let res = RouteResponder(routes: routes).getResponse(to: request)
-      let expected = "\n\nmmmm chocolate\n\nGET /eat_cookie HTTP/1.1".toBytes
+      let expected = "mmmm chocolate\n\nGET /eat_cookie HTTP/1.1".toBytes
 
       XCTAssertEqual(res.body!, expected)
     }
@@ -232,7 +232,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(auth: nil, includeLogs: false, allowedMethods: [.Get, .Put, .Patch])
       let routes = ["/file1": route]
 
-      let expected = "\n\nthis is a text file.".toBytes
+      let expected = "this is a text file.".toBytes
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
       XCTAssertEqual(response.body!, expected)
@@ -252,7 +252,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/image.jpeg": route]
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
-      let expected = "\n\nsome stuff".toBytes
+      let expected = "some stuff".toBytes
 
       XCTAssertEqual(response.body!, expected)
     }
@@ -269,7 +269,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/file1.txt": route]
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
-      let expected = "\n\nsome stuff\n\nGET /file1.txt HTTP/1.1".toBytes
+      let expected = "some stuff\n\nGET /file1.txt HTTP/1.1".toBytes
 
       XCTAssertEqual(response.body!, expected)
     }
@@ -305,7 +305,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(auth: nil, includeLogs: false, allowedMethods: [.Get])
       let routes = ["/partial_content.txt": route]
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
-      let expected = "\n\n is a file that contains text to read part of in order to fulfill a 206.\n".toBytes
+      let expected = " is a file that contains text to read part of in order to fulfill a 206.\n".toBytes
 
       XCTAssertEqual(response.body!, expected)
     }
@@ -325,7 +325,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/": route]
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
-      let expected = "\n\n<a href=\"/file1\">file1</a><br><a href=\"/file2\">file2</a>".toBytes
+      let expected = "<a href=\"/file1\">file1</a><br><a href=\"/file2\">file2</a>".toBytes
 
       XCTAssertEqual(response.body!, expected)
     }
@@ -340,7 +340,7 @@ class RouteResponderTest: XCTestCase {
       let routes = ["/parameters": route]
 
       let response = RouteResponder(routes: routes).getResponse(to: request)
-      let expected = "\n\nvariable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2 = stuff"
+      let expected = "variable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2 = stuff"
 
       XCTAssertEqual(response.body!, expected.toBytes)
     }
@@ -377,7 +377,7 @@ class RouteResponderTest: XCTestCase {
 
       let response = responder.getResponse(to: getRequest)
 
-      let expected = "\n\npatched content"
+      let expected = "patched content"
 
       XCTAssertEqual(response.body!, expected.toBytes)
     }
@@ -421,7 +421,7 @@ class RouteResponderTest: XCTestCase {
       let _ = responder.getResponse(to: postRequest)
       let response = responder.getResponse(to: getRequest)
 
-      let expected = "\n\ndata=fatcat"
+      let expected = "data=fatcat"
 
       XCTAssertEqual(response.body!, expected.toBytes)
     }
@@ -443,7 +443,7 @@ class RouteResponderTest: XCTestCase {
       let _ = responder.getResponse(to: putRequest)
       let response = responder.getResponse(to: getRequest)
 
-      let expected = "\n\ndata=hamilton"
+      let expected = "data=hamilton"
 
       XCTAssertEqual(response.body!, expected.toBytes)
     }
@@ -481,7 +481,7 @@ class RouteResponderTest: XCTestCase {
       let response = RouteResponder(routes: routes).getResponse(to: request)
 
       XCTAssertEqual(response.statusCode, "418 I'm a teapot")
-      XCTAssertEqual(response.body!, "\n\nI'm a teapot".toBytes)
+      XCTAssertEqual(response.body!, "I'm a teapot".toBytes)
     }
 
   // Appending body to response w/ image content
@@ -498,7 +498,7 @@ class RouteResponderTest: XCTestCase {
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
-      XCTAssertEqual(response.body!, "\n\nsome encoded stuff".toBytes)
+      XCTAssertEqual(response.body!, "some encoded stuff".toBytes)
     }
 
     func testItDoesNotIncludeLogsWhenResponseIsAnImage() {
@@ -514,7 +514,7 @@ class RouteResponderTest: XCTestCase {
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
-      XCTAssertEqual(response.body!, "\n\nsome encoded stuff".toBytes)
+      XCTAssertEqual(response.body!, "some encoded stuff".toBytes)
     }
 
     func testItDoesNotIncludeCookiePrefixWhenResponseIsAnImage() {
@@ -530,7 +530,7 @@ class RouteResponderTest: XCTestCase {
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
-      XCTAssertEqual(response.body!, "\n\nsome encoded stuff".toBytes)
+      XCTAssertEqual(response.body!, "some encoded stuff".toBytes)
     }
 
     func testItDoesNotIncludePartialResponseWhenResponseIsAnImage() {
@@ -546,7 +546,7 @@ class RouteResponderTest: XCTestCase {
 
       let response = RouteResponder(routes: routes, data: contents).getResponse(to: request)
 
-      XCTAssertEqual(response.body!, "\n\nsome encoded stuff".toBytes)
+      XCTAssertEqual(response.body!, "some encoded stuff".toBytes)
     }
 
 

--- a/Tests/ResponseFormattersTests/ContentFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/ContentFormatterTest.swift
@@ -16,7 +16,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/file1", data: contents)
     contentFormatter.execute(on: &response)
 
-    XCTAssertEqual(response.body!, "\n\nthis is a text file.".toBytes)
+    XCTAssertEqual(response.body!, "this is a text file.".toBytes)
   }
 
   func testItCanUpdateContentTypeHeaderWhenExtensionIsMissing() {
@@ -42,7 +42,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/image.jpeg", data: contents)
     contentFormatter.execute(on: &response)
 
-    XCTAssertEqual(response.body!, "\n\nsome encoded stuff".toBytes)
+    XCTAssertEqual(response.body!, "some encoded stuff".toBytes)
   }
 
   func testItCanUpdateContentTypeHeaderWithJPEG() {

--- a/Tests/ResponseFormattersTests/CookieFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/CookieFormatterTest.swift
@@ -12,7 +12,7 @@ class CookieFormatterTest: XCTestCase {
 
     CookieFormatter(for: request, prefix: cookiePrefix).execute(on: &response)
 
-    XCTAssertEqual(response.body!, "\n\nEat".toBytes)
+    XCTAssertEqual(response.body!, "Eat".toBytes)
   }
 
   func testItCanAddSetCookieHeaderToResponse() {
@@ -34,7 +34,7 @@ class CookieFormatterTest: XCTestCase {
 
     CookieFormatter(for: request, prefix: cookiePrefix).execute(on: &response)
 
-    XCTAssertEqual(response.body!, "\n\nwow chocolate".toBytes)
+    XCTAssertEqual(response.body!, "wow chocolate".toBytes)
   }
 
   func testItWillNotAppendIfNoCookieHeader() {

--- a/Tests/ResponseFormattersTests/DirectoryLinksFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/DirectoryLinksFormatterTest.swift
@@ -11,7 +11,7 @@ class DirectoryLinksFormatterTest: XCTestCase {
 
     DirectoryLinksFormatter(files: files).execute(on: &response)
 
-    let expected = "\n\n<a href=\"/file1\">file1</a><br><a href=\"/file2\">file2</a>"
+    let expected = "<a href=\"/file1\">file1</a><br><a href=\"/file2\">file2</a>"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }

--- a/Tests/ResponseFormattersTests/LogsFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/LogsFormatterTest.swift
@@ -11,7 +11,7 @@ class LogsFormatterTest: XCTestCase {
     let logsFormatter = LogsFormatter(logs: existingLogs)
     logsFormatter.execute(on: &response)
 
-    let expected = "\n\nGET /someRoute HTTP/1.1"
+    let expected = "GET /someRoute HTTP/1.1"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }

--- a/Tests/ResponseFormattersTests/ParamsFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/ParamsFormatterTest.swift
@@ -20,7 +20,7 @@ class ParamsFormatterTest: XCTestCase {
     var response = HTTPResponse(status: TwoHundred.Ok)
 
     ParamsFormatter(for: request.params).execute(on: &response)
-    let expected = "\n\nvariable_1 = Operators"
+    let expected = "variable_1 = Operators"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }
@@ -31,7 +31,7 @@ class ParamsFormatterTest: XCTestCase {
     var response = HTTPResponse(status: TwoHundred.Ok)
 
     ParamsFormatter(for: request.params).execute(on: &response)
-    let expected = "\n\nvariable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?"
+    let expected = "variable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }
@@ -42,7 +42,7 @@ class ParamsFormatterTest: XCTestCase {
     var response = HTTPResponse(status: TwoHundred.Ok)
 
     ParamsFormatter(for: request.params).execute(on: &response)
-    let expected = "\n\nvariable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2 = stuff"
+    let expected = "variable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2 = stuff"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }

--- a/Tests/ResponseFormattersTests/PartialFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/PartialFormatterTest.swift
@@ -13,7 +13,7 @@ class PartialFormatterTest: XCTestCase {
     let partialFormatter = PartialFormatter(for: request.headers["range"])
 
     partialFormatter.execute(on: &response)
-    let expected = "\n\n is a file that contains text to read part of in order to fulfill a 206.\n"
+    let expected = " is a file that contains text to read part of in order to fulfill a 206.\n"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }
@@ -28,7 +28,7 @@ class PartialFormatterTest: XCTestCase {
 
     partialFormatter.execute(on: &response)
 
-    let expected = "\n\n 206.\n"
+    let expected = " 206.\n"
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }
@@ -40,7 +40,7 @@ class PartialFormatterTest: XCTestCase {
     var response = HTTPResponse(status: TwoHundred.Ok, body: content)
 
     PartialFormatter(for: request.headers["range"]).execute(on: &response)
-    let expected = "\n\nThis "
+    let expected = "This "
 
     XCTAssertEqual(response.body!, expected.toBytes)
   }

--- a/Tests/ResponsesTests/ResponseTest.swift
+++ b/Tests/ResponsesTests/ResponseTest.swift
@@ -22,14 +22,13 @@ class ResponseTest: XCTestCase {
     XCTAssertEqual(response.statusCode, "418 I'm a teapot")
   }
 
-  func testItCanFormatItsBody() {
+  func testItHasABody() {
     let headers = ["Content-Type": "ABCD"]
     let body = "BODY"
 
     let response = HTTPResponse(status: ok, headers: headers, body: body)
-    let expected: [UInt8] = Array("\n\n\(body)".utf8)
 
-    XCTAssertEqual(response.body!, expected)
+    XCTAssertEqual(response.body!, body.toBytes)
   }
 
   func testItCanFormatItsHeaders() {
@@ -49,9 +48,9 @@ class ResponseTest: XCTestCase {
 
     let rawHeaders = "Content-Type:text/html\r\nWWW-Authenticate:Basic realm=\"simple\""
     let body = "BODY"
-    let formattedStatus: [UInt8] = Array("HTTP/1.1 200 OK\r\n".utf8)
-    let formattedHeaders: [UInt8] = Array(rawHeaders.utf8)
-    let formattedBody: [UInt8] = Array("\n\n\(body)".utf8)
+    let formattedStatus = "HTTP/1.1 200 OK\r\n".toBytes
+    let formattedHeaders = rawHeaders.toBytes
+    let formattedBody = "\n\n\(body)".toBytes
     let formattedResponse = formattedStatus + formattedHeaders + formattedBody
 
     let response = HTTPResponse(status: ok, headers: headers, body: body)


### PR DESCRIPTION
- Remove prepending of newline to HTTPResponse body
- adjust formatted getter to prepend newlines to body.
- change tests to expect response body without newlines