### PR TITLE
Close #143: Remove toData force downcast

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,12 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "Socks",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/socks.git",
+      "version": "1.2.7"
+    }
+  ],
+  "version": 1
+}

--- a/Sources/Responses/Array<UInt8>+Extension.swift
+++ b/Sources/Responses/Array<UInt8>+Extension.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-public extension Sequence where Iterator.Element == UInt8 {
+public extension Array where Element == UInt8 {
   var toData: Data {
-    // type cast as workaround to bug fixed in Swift 3.1
-    return Data(bytes: self as! [UInt8])
+    return Data(bytes: self)
   }
 }


### PR DESCRIPTION
- Remove force downcast in Array<UInt8> extension
- Upgrade to Swift 3.1