### PR TITLE
Close #136: Etag Response header

### DIFF
--- a/Sources/Responders/TwoHundredResponder.swift
+++ b/Sources/Responders/TwoHundredResponder.swift
@@ -48,7 +48,10 @@ class TwoHundredResponder {
 
     case let verb where verb == .Patch:
       data.update(request.path, withVal: request.body)
-      return HTTPResponse(status: TwoHundred.NoContent)
+      let headers = request.headers["if-match"].map { ["ETag": $0] }
+
+      return HTTPResponse(status: TwoHundred.NoContent, headers: headers ?? [:])
+
 
     case let verb where verb == .Delete:
       data.remove(at: request.path)

--- a/Sources/Responders/TwoHundredResponder.swift
+++ b/Sources/Responders/TwoHundredResponder.swift
@@ -50,7 +50,7 @@ class TwoHundredResponder {
       data.update(request.path, withVal: request.body)
       let headers = request.headers["if-match"].map { ["ETag": $0] }
 
-      return HTTPResponse(status: TwoHundred.NoContent, headers: headers ?? [:])
+      return HTTPResponse(status: TwoHundred.NoContent, headers: headers)
 
 
     case let verb where verb == .Delete:

--- a/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
+++ b/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
@@ -13,7 +13,7 @@ public class DirectoryLinksFormatter: ResponseFormatter {
       return response
     }
 
-    guard response.headers["Content-Type"] != "text/plain" else {
+    guard response.headers?["Content-Type"] != "text/plain" else {
       return response
     }
 

--- a/Sources/Responses/HTTPResponse.swift
+++ b/Sources/Responses/HTTPResponse.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public struct HTTPResponse {
   public let statusCode: String
-  public let headers: [String: String]
+  public let headers: [String: String]?
   public let body: [UInt8]?
   public let crlf: String = "\r\n"
   public let headerDivide: String = ":"
   public let transferProtocol: String = "HTTP/1.1"
   public let bodyDivide: String = "\n\n"
 
-  public init(status: HTTPStatusCode, headers: [String: String] = [:], body: BytesRepresentable? = nil) {
+  public init(status: HTTPStatusCode, headers: [String: String]? = nil, body: BytesRepresentable? = nil) {
     self.statusCode = status.description
     self.headers = headers
     self.body = body?.toBytes
@@ -19,8 +19,10 @@ public struct HTTPResponse {
     return self.body.map { ($0 + "\n\n".toBytes).toData + newBody } ?? newBody
   }
 
-  public func updateHeaders(with newHeaders: [String: String]) -> [String: String] {
-    var existingHeaders = self.headers
+  public func updateHeaders(with newHeaders: [String: String]) -> [String: String]? {
+    guard var existingHeaders = self.headers else {
+      return newHeaders
+    }
 
     for (k, v) in newHeaders {
       existingHeaders[k] = v
@@ -30,7 +32,7 @@ public struct HTTPResponse {
   }
 
   public var formatted: [UInt8] {
-    let joinedHeaders = headers.map { $0 + headerDivide + $1 }.joined(separator: crlf)
+    let joinedHeaders = headers?.map { $0 + headerDivide + $1 }.joined(separator: crlf) ?? ""
     let statusLine = "\(transferProtocol) \(statusCode + crlf)"
     let formattedBody = body.map { "\n\n".toBytes + $0 } ?? []
 

--- a/Sources/Responses/String+BytesRepresentable.swift
+++ b/Sources/Responses/String+BytesRepresentable.swift
@@ -12,9 +12,9 @@ public extension String {
   }
 
   init?(response: HTTPResponse) {
-    let joinedHeaders = response.headers
+    let joinedHeaders = response.headers?
                                 .map { $0 + response.headerDivide + $1 }
-                                .joined(separator: response.crlf)
+                                .joined(separator: response.crlf) ?? ""
 
     let statusLine = "\(response.transferProtocol) \(response.statusCode + response.crlf)"
 

--- a/Sources/Util/ResourceData.swift
+++ b/Sources/Util/ResourceData.swift
@@ -15,7 +15,7 @@ public class ResourceData {
       return
     }
 
-    contents.updateValue(Data(bytes: confirmedValue.toBytes), forKey: key)
+    contents.updateValue(confirmedValue.toData, forKey: key)
   }
 
   public func get(_ key: String) -> String? {

--- a/Tests/RespondersTests/HTTPResponse+Equatable.swift
+++ b/Tests/RespondersTests/HTTPResponse+Equatable.swift
@@ -4,8 +4,11 @@ extension HTTPResponse: Equatable {
   static public func == (lhs: HTTPResponse, rhs: HTTPResponse) -> Bool {
     switch (lhs, rhs) {
     default:
+      let leftHeaders = lhs.headers ?? [:]
+      let rightHeaders = rhs.headers ?? [:]
+
       return lhs.statusCode == rhs.statusCode &&
-              lhs.headers == rhs.headers &&
+              leftHeaders == rightHeaders &&
                 lhs.body ?? [] == rhs.body ?? []
     }
   }

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -149,6 +149,19 @@ class TwoHundredResponderTest: XCTestCase {
       XCTAssertEqual(response.body!, "new cheese".toBytes)
     }
 
+    func testItSendsETagInHeaderIfPresentInRequest() {
+      let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\nIf-Match: abcde\r\nnew cheese")!
+
+      let data = ResourceData(["/someRoute": "cheese".toData])
+
+      let route = Route(allowedMethods: [.Get, .Patch])
+
+      let responder = TwoHundredResponder(route: route, data: data)
+      let response = responder.response(to: patchRequest)
+
+      XCTAssertEqual(response.headers["ETag"]!, "abcde")
+    }
+
     func testItSendsA204StatusInResponseToPatch() {
       let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\nnew cheese")!
 

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -159,7 +159,7 @@ class TwoHundredResponderTest: XCTestCase {
       let responder = TwoHundredResponder(route: route, data: data)
       let response = responder.response(to: patchRequest)
 
-      XCTAssertEqual(response.headers["ETag"]!, "abcde")
+      XCTAssertEqual(response.headers!["ETag"]!, "abcde")
     }
 
     func testItSendsA204StatusInResponseToPatch() {
@@ -181,7 +181,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let response = TwoHundredResponder(route: route).response(to: request)
 
-      XCTAssertEqual(response.headers["Allow"]!, "OPTIONS,POST,HEAD")
+      XCTAssertEqual(response.headers!["Allow"]!, "OPTIONS,POST,HEAD")
     }
 
     func testItCanHandleHeadRequests() {

--- a/Tests/ResponseFormattersTests/ContentFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/ContentFormatterTest.swift
@@ -29,7 +29,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/file1", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Content-Type"]!, "text/html")
+    XCTAssertEqual(newResponse.headers!["Content-Type"]!, "text/html")
   }
 
   func testItCanAppendContentTypeHeaderToExistingHeaders() {
@@ -42,7 +42,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/file1", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers, ["Date": "today", "Content-Type": "text/html"])
+    XCTAssertEqual(newResponse.headers!, ["Date": "today", "Content-Type": "text/html"])
   }
 
   func testItCanUpdateBodyWithImageContents() {
@@ -68,7 +68,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/image.jpeg", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Content-Type"]!, "image/jpeg")
+    XCTAssertEqual(newResponse.headers!["Content-Type"]!, "image/jpeg")
   }
 
   func testItCanUpdateContentTypeHeaderWithPNG() {
@@ -81,7 +81,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/image.png", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Content-Type"]!, "image/png")
+    XCTAssertEqual(newResponse.headers!["Content-Type"]!, "image/png")
   }
 
   func testItCanUpdateContentTypeHeaderWithGIF() {
@@ -94,7 +94,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/image.gif", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Content-Type"]!, "image/gif")
+    XCTAssertEqual(newResponse.headers!["Content-Type"]!, "image/gif")
   }
 
   func testItCanUpdateContentTypeHeaderWithTXT() {
@@ -107,7 +107,7 @@ class ContentFormatterTest: XCTestCase {
     let contentFormatter = ContentFormatter(for: "/file1.txt", data: contents)
     let newResponse = contentFormatter.addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Content-Type"]!, "text/plain")
+    XCTAssertEqual(newResponse.headers!["Content-Type"]!, "text/plain")
   }
 
   func testItCanAppendFileDataToExistingResponseBody() {

--- a/Tests/ResponseFormattersTests/CookieFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/CookieFormatterTest.swift
@@ -34,7 +34,7 @@ class CookieFormatterTest: XCTestCase {
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers["Set-Cookie"]!, "type=chocolate")
+    XCTAssertEqual(newResponse.headers!["Set-Cookie"]!, "type=chocolate")
   }
 
   func testItCanAddSetCookieHeaderToExistingResponseHeaders() {
@@ -45,7 +45,7 @@ class CookieFormatterTest: XCTestCase {
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
-    XCTAssertEqual(newResponse.headers, ["Content-Type": "text/html", "Set-Cookie": "type=chocolate"])
+    XCTAssertEqual(newResponse.headers!, ["Content-Type": "text/html", "Set-Cookie": "type=chocolate"])
   }
 
   func testItCanAppendCookiePrefixAfterCookieIsSet() {
@@ -68,7 +68,7 @@ class CookieFormatterTest: XCTestCase {
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
     XCTAssertEqual(newResponse.body!, "wow chocolate wow".toBytes)
-    XCTAssertEqual(newResponse.headers["Set-Cookie"], "type=oatmeal")
+    XCTAssertEqual(newResponse.headers!["Set-Cookie"], "type=oatmeal")
   }
 
   func testItWillNotAppendIfNoCookieHeader() {

--- a/Tests/ResponsesTests/ResponseTest.swift
+++ b/Tests/ResponsesTests/ResponseTest.swift
@@ -39,7 +39,7 @@ class ResponseTest: XCTestCase {
 
     let response = HTTPResponse(status: ok, headers: headers, body: body)
 
-    XCTAssertEqual(response.headers, headers)
+    XCTAssertEqual(response.headers!, headers)
   }
 
   func testItCanFormatItselfWithExistingBody() {


### PR DESCRIPTION
- Optional in TwoHundredResponder#response Patch path for Etag for response header.