### PR TITLE
Close #154: HTTPParameters Refactor

### DIFF
--- a/Sources/Requests/Dictionary+Extension.swift
+++ b/Sources/Requests/Dictionary+Extension.swift
@@ -1,0 +1,7 @@
+public extension Dictionary where Key == String, Value == String {
+  init(params: HTTPParameters) {
+    self = [:]
+
+    zip(params.keys, params.values).forEach { self[$0] = $1 }
+  }
+}

--- a/Sources/Requests/HTTPParameters.swift
+++ b/Sources/Requests/HTTPParameters.swift
@@ -1,23 +1,20 @@
 public class HTTPParameters {
-  public let rawParams: String
   public let keyValueSeparator: String = "="
   public let multipleSeparator: String = "&"
   public var keys: [String] = []
   public var values: [String] = []
 
-  public var isEmpty: Bool {
-    return keys.isEmpty && values.isEmpty
-  }
-
-  public init(for rawParams: String) {
-    self.rawParams = rawParams
-
+  public init?(for rawParams: String) {
     let flattenedParams = rawParams.components(separatedBy: multipleSeparator)
                                    .flatMap { $0.components(separatedBy: keyValueSeparator) }
                                    .filter { !$0.isEmpty }
 
+    guard flattenedParams.count >= 2 else {
+      return nil
+    }
+
     for (index, param) in flattenedParams.enumerated() {
-      if index == flattenedParams.count - 1 && flattenedParams.count % 2 != 0 {
+      if index == flattenedParams.count - 1, flattenedParams.count % 2 != 0 {
         break
       }
 
@@ -29,38 +26,8 @@ public class HTTPParameters {
     }
   }
 
-  public func toDictionary() -> [String: String] {
-    var matchedParams: [String: String] = [:]
-
-    if isEmpty {
-      return matchedParams
-    }
-
-    for (index, key) in keys.enumerated() {
-      matchedParams[key] = values[index]
-    }
-
-    return matchedParams
-  }
-
   private func decode(_ rawParams: String) -> String {
     return rawParams.removingPercentEncoding ?? rawParams
   }
 
-}
-
-extension String {
-  public init?(parameters: HTTPParameters) {
-    if parameters.isEmpty {
-      return nil
-    }
-
-    var result = ""
-
-    for (index, paramKey) in parameters.keys.enumerated() {
-      result += (paramKey + parameters.keyValueSeparator + parameters.values[index] + "\n")
-    }
-
-    self.init(result.trimmingCharacters(in: .newlines))
-  }
 }

--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -9,7 +9,6 @@ public struct HTTPRequest {
   public let headerDivide: String = ":"
   public let transferProtocol: String = "HTTP/1.1"
   private let parameterDivide: String = "?"
-  private let parameterKeyValueSeparator: String = "="
 
   public var headers: [String: String] = [:]
 
@@ -29,15 +28,11 @@ public struct HTTPRequest {
 
     let splitPath = fullPath.components(separatedBy: parameterDivide)
 
-    let separator = parameterKeyValueSeparator
     verb = HTTPRequestMethod(rawValue: givenVerb.capitalized)
 
     path = fullPath.range(of: parameterDivide).map { fullPath.substring(to: $0.lowerBound) } ?? fullPath
 
-    params = splitPath.first(where: { $0.contains(separator) }).flatMap { params -> HTTPParameters? in
-      let dividedParams = params.components(separatedBy: separator).filter { !$0.isEmpty }
-      return dividedParams.count >= 2 ? HTTPParameters(for: params) : nil
-    }
+    params = splitPath.first(where: { $0.contains("=") }).flatMap { HTTPParameters(for: $0) }
 
     body = requestTail.contains(headerDivide) ? nil : requestTail
 

--- a/Sources/Requests/String+Extension.swift
+++ b/Sources/Requests/String+Extension.swift
@@ -1,0 +1,10 @@
+extension String {
+  public init?(params: HTTPParameters) {
+
+    let result = zip(params.keys, params.values).reduce("") { res, zipped in
+      res + (zipped.0 + params.keyValueSeparator + zipped.1 + "\n")
+    }
+
+    self.init(result.trimmingCharacters(in: .newlines))
+  }
+}

--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -17,7 +17,7 @@ public class CookieFormatter: ResponseFormatter {
     }
 
     let cookieHeaders = request.params.flatMap { params -> [String: String]? in
-      String(parameters: params).map { ["Set-Cookie": $0] }
+      String(params: params).map { ["Set-Cookie": $0] }
     }
 
     return HTTPResponse(

--- a/Sources/ResponseFormatters/ParamsFormatter.swift
+++ b/Sources/ResponseFormatters/ParamsFormatter.swift
@@ -13,8 +13,7 @@ public class ParamsFormatter: ResponseFormatter {
       return response
     }
 
-    let formattedParams = validParams
-                           .toDictionary()
+    let formattedParams = [String: String](params: validParams)
                            .map { $0 + " = " + $1 }
                            .joined(separator: "\n")
                            .toData

--- a/Tests/RequestsTests/ParamsTest.swift
+++ b/Tests/RequestsTests/ParamsTest.swift
@@ -5,23 +5,23 @@ class ParamsTest: XCTestCase {
   func testItCanBeAString() {
     let fullPath = "my=params"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
-    XCTAssertEqual(String(parameters: params)!, "my=params")
+    XCTAssertEqual(String(params: params)!, "my=params")
   }
 
   func testItCanBeADynamicString() {
     let fullPath = "type=oatmeal"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
-    XCTAssertEqual(String(parameters: params)!, "type=oatmeal")
+    XCTAssertEqual(String(params: params)!, "type=oatmeal")
   }
 
   func testItHasKeys() {
     let fullPath = "type=oatmeal"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.keys, ["type"])
   }
@@ -29,7 +29,7 @@ class ParamsTest: XCTestCase {
   func testItHasDynamicKeys() {
     let fullPath = "my=params"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.keys, ["my"])
   }
@@ -37,7 +37,7 @@ class ParamsTest: XCTestCase {
   func testItHasValues() {
     let fullPath = "type=oatmeal"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.values, ["oatmeal"])
   }
@@ -45,76 +45,61 @@ class ParamsTest: XCTestCase {
   func testItHasDynamicValues() {
     let fullPath = "type=chocolate"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.values, ["chocolate"])
   }
 
-  func testItCanHandleBlankParamsToString() {
+  func testItCantHandleSingleMissingValue() {
     let fullPath = "type="
 
     let params = HTTPParameters(for: fullPath)
 
-    XCTAssertNil(String(parameters: params))
+    XCTAssertNil(params)
   }
 
   func testItCanHandleNestedBlankParamValuesToString() {
     let fullPath = "type=chocolate&wow="
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
-    XCTAssertEqual(String(parameters: params)!, "type=chocolate")
+    XCTAssertEqual(String(params: params)!, "type=chocolate")
   }
 
   func testItCanHandleNestedBlankParamKeysToString() {
     let fullPath = "type=chocolate&=wow"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
-    XCTAssertEqual(String(parameters: params)!, "type=chocolate")
+    XCTAssertEqual(String(params: params)!, "type=chocolate")
   }
 
-  func testItCanHandleBlankParamsKeys() {
+  func testItCantHandleSingleMissingKey() {
     let fullPath = "=stuff"
 
     let params = HTTPParameters(for: fullPath)
 
-    XCTAssertEqual(params.keys, [])
-  }
-
-  func testItCanHandleBlankParamsValues() {
-    let fullPath = "type="
-
-    let params = HTTPParameters(for: fullPath)
-
-    XCTAssertEqual(params.values, [])
-  }
-
-  func testItCanHandleInvalidParamsToDictionary() {
-    let fullPath = "type="
-
-    let params = HTTPParameters(for: fullPath)
-
-    XCTAssertEqual(params.toDictionary(), [:])
+    XCTAssertNil(params)
   }
 
   func testItCanHandleNestedInvalidParamsToDict() {
     let path = "type=chocolate&stuff="
-    let params = HTTPParameters(for: path)
+    let params = HTTPParameters(for: path)!
+    let result = [String: String](params: params)
 
-    XCTAssertEqual(params.toDictionary(), ["type": "chocolate"])
+    XCTAssertEqual(result, ["type": "chocolate"])
   }
 
   func testItCanHandleNestedInvalidParamsKeys() {
     let path = "type=chocolate&stuff="
-    let params = HTTPParameters(for: path)
+    let params = HTTPParameters(for: path)!
 
     XCTAssertEqual(params.keys, ["type"])
   }
 
   func testItCanHandleNestedInvalidParamsVals() {
     let path = "type=chocolate&=stuff"
-    let params = HTTPParameters(for: path)
+    let params = HTTPParameters(for: path)!
 
     XCTAssertEqual(params.values, ["chocolate"])
   }
@@ -122,31 +107,33 @@ class ParamsTest: XCTestCase {
   func testItCanConvertToDictionary() {
     let fullPath = "type=oatmeal"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
+    let result = [String: String](params: params)
 
-    XCTAssertEqual(params.toDictionary(), ["type": "oatmeal"])
+    XCTAssertEqual(result, ["type": "oatmeal"])
   }
 
   func testItCanDynamicallyConvertToDictionary() {
     let fullPath = "my=params"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
+    let result = [String: String](params: params)
 
-    XCTAssertEqual(params.toDictionary(), ["my": "params"])
+    XCTAssertEqual(result, ["my": "params"])
   }
 
   func testItCanHandleMultipleParamsToString() {
     let fullPath = "my=params&cool=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
-    XCTAssertEqual(String(parameters: params)!, "my=params\ncool=stuff")
+    XCTAssertEqual(String(params: params)!, "my=params\ncool=stuff")
   }
 
   func testItCanHandleMultipleParamsKeys() {
     let fullPath = "my=params&cool=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.keys, ["my", "cool"])
   }
@@ -154,32 +141,51 @@ class ParamsTest: XCTestCase {
   func testItCanHandleMultipleParamsVals() {
     let fullPath = "my=params&cool=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.values, ["params", "stuff"])
+  }
+
+  func testItCanHandleInvalidNestedParamKeys() {
+    let fullPath = "my=params&=cool"
+
+    let params = HTTPParameters(for: fullPath)!
+    let result = [String: String](params: params)
+
+    XCTAssertEqual(result, ["my": "params"])
+  }
+
+  func testItCanHandleInvalidNestedParamVals() {
+    let fullPath = "my=params&cool"
+
+    let params = HTTPParameters(for: fullPath)!
+    let result = [String: String](params: params)
+
+    XCTAssertEqual(result, ["my": "params"])
   }
 
   func testItCanHandleMultipleParamsToDict() {
     let fullPath = "my=params&cool=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
+    let result = [String: String](params: params)
 
-    XCTAssertEqual(params.toDictionary(), ["my": "params", "cool": "stuff"])
+    XCTAssertEqual(result, ["my": "params", "cool": "stuff"])
   }
 
   func testItCanHandleEncodedParamsToString() {
     let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
     let expected = "variable_1=Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?\nvariable_2=stuff"
 
-    XCTAssertEqual(String(parameters: params)!, expected)
+    XCTAssertEqual(String(params: params)!, expected)
   }
 
   func testItCanHandleEncodedParamsKeys() {
     let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D&variable_2=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
 
     XCTAssertEqual(params.keys, ["variable_1", "variable_2"])
   }
@@ -187,7 +193,7 @@ class ParamsTest: XCTestCase {
   func testItCanHandleEncodedParamsVals() {
     let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
     let expected = ["Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "stuff"]
 
     XCTAssertEqual(params.values, expected)
@@ -196,10 +202,20 @@ class ParamsTest: XCTestCase {
   func testItCanHandleEncodedParamsToDict() {
     let fullPath = "variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
 
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: fullPath)!
     let expected = ["variable_1": "Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "variable_2": "stuff"]
+    let result = [String: String](params: params)
 
-    XCTAssertEqual(params.toDictionary(), expected)
+    XCTAssertEqual(result, expected)
   }
 
+  func testItCanHandleNonEncodedParams() {
+    let fullPath = "variable_1=Operators%k0%-3C%2!C%2m%3j%&variable_2=stuff"
+
+    let params = HTTPParameters(for: fullPath)!
+    let expected = ["variable_1": "Operators%k0%-3C%2!C%2m%3j%", "variable_2": "stuff"]
+    let result = [String: String](params: params)
+
+    XCTAssertEqual(result, expected)
+  }
 }

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -101,17 +101,17 @@ class RequestTest: XCTestCase {
     func testItHasParams() {
         let rawRequest = "GET /cookie?type=chocolate HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
         let request = HTTPRequest(for: rawRequest)!
+        let result = [String: String](params: request.params!)
 
-
-        XCTAssertEqual(request.params!.toDictionary(), ["type": "chocolate"])
+        XCTAssertEqual(result, ["type": "chocolate"])
     }
 
     func testItCanHandleDifferentParams() {
         let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
         let request = HTTPRequest(for: rawRequest)!
+        let result = [String: String](params: request.params!)
 
-
-        XCTAssertEqual(request.params!.toDictionary(), ["roast": "beef"])
+        XCTAssertEqual(result, ["roast": "beef"])
     }
 
     func testHavingParamsDoesntChangePath() {


### PR DESCRIPTION
  - [String: String] init extension for parameters.
  - remove redundancy in HTTPRequest for HTTPParameters failable init.
  - move params extensions to separate files,
  - test for decoding of botched encoding in params test.