### PR TITLE
Close #89: Log Successful Requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
       Target(name: "Router", dependencies: [
         .Target(name: "Requests"),
         .Target(name: "Responses"),
-        .Target(name: "Responders")
+        .Target(name: "Responders"),
+        .Target(name: "Util")
       ]),
       Target(name: "Util", dependencies: [
         .Target(name: "Errors"),

--- a/Sources/Responses/String+BytesRepresentable.swift
+++ b/Sources/Responses/String+BytesRepresentable.swift
@@ -11,14 +11,14 @@ public extension String {
     return self.toBytes.toData
   }
 
-  init?(response: HTTPResponse) {
+  init(response: HTTPResponse) {
     let joinedHeaders = response.headers?
                                 .map { $0 + response.headerDivide + $1 }
                                 .joined(separator: response.crlf) ?? ""
 
     let statusLine = "\(response.transferProtocol) \(response.statusCode + response.crlf)"
 
-    self.init(statusLine + joinedHeaders)
+    self.init(statusLine + joinedHeaders)!
   }
 
 }

--- a/Tests/UtilTests/DateHelperTests.swift
+++ b/Tests/UtilTests/DateHelperTests.swift
@@ -1,26 +1,11 @@
 import XCTest
-import Foundation
 @testable import Util
-
-class MockCalendar: Calendarizable {
-  func currentHour(from today: Date) -> Int { return 8 }
-
-  func currentMinute(from today: Date) -> Int { return 45 }
-
-  func currentSecond(from today: Date) -> Int { return 30 }
-}
-
-class MockFormatter: DateFormattable {
-  var dateFormat: String! = "mm/dd/yyyy"
-
-  func string(from today: Date) -> String {
-    return "04/10/2017"
-  }
-}
 
 class DateHelperTest: XCTestCase {
   func testItFormatsATimestamp() {
-    let dateHelper = DateHelper(today: Date(), calendar: MockCalendar(), formatter: MockFormatter())
+    let mockCalendar = MockCalendar(hour: 8, minute: 45, second: 30)
+    let mockFormatter = MockFormatter(month: "04", day: "10", year: "2017")
+    let dateHelper = DateHelper(today: Date(), calendar: mockCalendar, formatter: mockFormatter)
 
     let timestamp = dateHelper.formatTimestamp(prefix: "TEST", dateSeparator: "/")
     let expected = "TEST-8:45:30--04/10/2017"

--- a/Tests/UtilTests/MockCalender.swift
+++ b/Tests/UtilTests/MockCalender.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Util
+
+public class MockCalendar: Calendarizable {
+  let hour: Int
+  let minute: Int
+  let second: Int
+
+  public init(hour: Int, minute: Int, second: Int) {
+    self.hour = hour
+    self.minute = minute
+    self.second = second
+  }
+
+  public func currentHour(from today: Date) -> Int { return hour }
+
+  public func currentMinute(from today: Date) -> Int { return minute }
+
+  public func currentSecond(from today: Date) -> Int { return second }
+}
+

--- a/Tests/UtilTests/MockFormatter.swift
+++ b/Tests/UtilTests/MockFormatter.swift
@@ -1,0 +1,21 @@
+import Util
+import Foundation
+
+public class MockFormatter: DateFormattable {
+  let month: String
+  let day: String
+  let year: String
+
+  public var dateFormat: String! = "mm/dd/yyyy"
+
+  public init(month: String, day: String, year: String) {
+    self.month = month
+    self.day = day
+    self.year = year
+  }
+
+  public func string(from today: Date) -> String {
+    return "\(month)/\(day)/\(year)"
+  }
+}
+


### PR DESCRIPTION
- Router#listen func to take onReceive callback
- main to pass in onReceive callback to Router at top-level
- Router with optional onReceive property
- Router with additional DateHelper init parameter