### PR TITLE
Close #141: Treat Empty Request Body on Put/Post/Patch as empty string

### DIFF
--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -34,10 +34,11 @@ public struct HTTPRequest {
 
     params = splitPath.first(where: { $0.contains("=") }).flatMap { HTTPParameters(for: $0) }
 
-    body = requestTail.contains(headerDivide) ? nil : requestTail
+    body = requestTail.isEmpty ? nil : requestTail
 
     headers = splitRequest
                .dropFirst()
+               .dropLast()
                .reduce([:], requestHeaders)
   }
 

--- a/Sources/Util/ResourceData.swift
+++ b/Sources/Util/ResourceData.swift
@@ -15,11 +15,7 @@ public class ResourceData {
   }
 
   public func update(_ key: String, withVal value: String?) {
-    guard let confirmedValue = value else {
-      return
-    }
-
-    contents.updateValue(confirmedValue, forKey: key)
+    contents.updateValue(value ?? "", forKey: key)
   }
 
   public func remove(at key: String) {

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -3,35 +3,28 @@ import XCTest
 
 class RequestTest: XCTestCase {
     func testItTakesRawRequestAndExtractsVerbGET() {
-        let rawRequest = "GET /log HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
+        let rawRequest = "GET /log HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertEqual(request.verb, .Get)
     }
 
     func testItTakesRawRequestAndExtractsVerbPOST() {
-        let rawRequest = "POST /log HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
+        let rawRequest = "POST /log HTTP/1.1\r\n\r\ndata=stuff"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertEqual(request.verb, .Post)
     }
 
-    func testItTakesRawRequestAndExtractsPathLog() {
-        let rawRequest = "GET /log HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
-        let request = HTTPRequest(for: rawRequest)!
-
-        XCTAssertEqual(request.path, "/log")
-    }
-
     func testItTakesRawRequestAndExtractsPathLogs() {
-        let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\n Connection: Keep-Alive\r\n User-Agent: Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding: gzip,deflate"
+        let rawRequest = "GET /logs HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertEqual(request.path, "/logs")
     }
 
     func testItTakesRawRequestAndExtractsAllValidHeaders() {
-        let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\nAuthorization: Basic YWRtaW46aHVudGVyMg==\r\n Connection: Keep-Alive\r\n User-Agent:Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding:gzip,deflate\r\nAccept-Charset: utf-8"
+        let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\nAuthorization: Basic YWRtaW46aHVudGVyMg==\r\n Connection: Keep-Alive\r\n User-Agent:Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding:gzip,deflate\r\nAccept-Charset: utf-8\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
         let expectedResult = [
           "host": "localhost:5000",
@@ -46,7 +39,7 @@ class RequestTest: XCTestCase {
     }
 
     func testItTakesRawRequestAndExtractsOnlyValidHeadersNoWhiteSpacesInHeader() {
-        let rawRequest = "POST /form HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /form HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
         let expectedResult = [
           "host": "yahoo.com",
@@ -59,10 +52,9 @@ class RequestTest: XCTestCase {
     }
 
     func testItIgnoresEmptyHeaders() {
-        let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
         let expectedResult = [
-          "connection": "Keep-Alive",
           "user-agent": "chrome",
           "accept-encoding": "gzip,deflate"
         ]
@@ -71,35 +63,35 @@ class RequestTest: XCTestCase {
     }
 
     func testItHasNoParams() {
-        let rawRequest = "GET /cookie HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertNil(request.params)
     }
 
     func testItHasInvalidParams() {
-        let rawRequest = "GET /cookie?sometihgnaksjnd HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?sometihgnaksjnd HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertNil(request.params)
     }
 
     func testItDoesntCreateParamsWithBlankValues() {
-        let rawRequest = "GET /cookie?sometihgnaksjnd= HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?sometihgnaksjnd= HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertNil(request.params)
     }
 
     func testItCanRecognizeBlankParamKey() {
-        let rawRequest = "GET /cookie?=sometihgnaksjnd HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?=sometihgnaksjnd HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
         XCTAssertNil(request.params)
     }
 
     func testItHasParams() {
-        let rawRequest = "GET /cookie?type=chocolate HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
         let result = [String: String](params: request.params!)
 
@@ -107,7 +99,7 @@ class RequestTest: XCTestCase {
     }
 
     func testItCanHandleDifferentParams() {
-        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
         let result = [String: String](params: request.params!)
 
@@ -115,7 +107,7 @@ class RequestTest: XCTestCase {
     }
 
     func testHavingParamsDoesntChangePath() {
-        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate"
+        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
         let request = HTTPRequest(for: rawRequest)!
 
 
@@ -123,7 +115,7 @@ class RequestTest: XCTestCase {
     }
 
     func testItHasABody() {
-      let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\ndata=fatcat"
+      let rawRequest = "POST /form HTTP/1.1\r\n\r\ndata=fatcat"
       let request = HTTPRequest(for: rawRequest)!
 
       XCTAssertEqual(request.body!, "data=fatcat")
@@ -134,5 +126,20 @@ class RequestTest: XCTestCase {
       let request = HTTPRequest(for: rawRequest)
 
       XCTAssertNil(request)
+    }
+
+    func testItCanHandleRequestsWithHeadersAndMissingBody() {
+      let rawRequest = "GET /cookie HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+
+      XCTAssertNil(request.body)
+    }
+
+    func testItCanHandleRequestsWithBodyAndMissingHeaders() {
+      let rawRequest = "POST /cookie HTTP/1.1\r\n\r\ndata:fatcat"
+      let request = HTTPRequest(for: rawRequest)!
+
+      XCTAssertEqual(request.headers, [:])
+      XCTAssertEqual(request.body!, "data:fatcat")
     }
 }

--- a/Tests/RespondersTests/FourHundredResponderTest.swift
+++ b/Tests/RespondersTests/FourHundredResponderTest.swift
@@ -9,7 +9,7 @@ class FourHundredResponderTest: XCTestCase {
   let route = Route(auth: "XYZ", allowedMethods: [.Get], redirectPath: "/")
 
   func testItReturns401WhenAuthDoesntMatch() {
-    let rawRequest = "GET /someRoute HTTP/1.1\r\nAuthorization: Basic ABC"
+    let rawRequest = "GET /someRoute HTTP/1.1\r\nAuthorization: Basic ABC\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!
 
     let responder = FourHundredResponder(route: route)
@@ -24,7 +24,7 @@ class FourHundredResponderTest: XCTestCase {
   }
 
   func testItReturnsMethodNotAllowedWhenMethodIsNotInConfig() {
-    let request = HTTPRequest(for: "POST /someRoute HTTP/1.1")!
+    let request = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\ndata=wow")!
 
     let route = Route(allowedMethods: [.Get])
 
@@ -37,7 +37,7 @@ class FourHundredResponderTest: XCTestCase {
   }
 
   func testItReturnsA416IfGivenEndRangeIsOutOfBounds() {
-    let rawRequest = "GET /someRoute HTTP/1.1\r\nRange: bytes=5-80"
+    let rawRequest = "GET /someRoute HTTP/1.1\r\nRange: bytes=5-80\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!
 
     let route = Route(allowedMethods: [.Get])
@@ -61,7 +61,7 @@ class FourHundredResponderTest: XCTestCase {
   }
 
   func testItReturnsA416IfGivenStartRangeIsOutOfBounds() {
-    let rawRequest = "GET /someRoute HTTP/1.1\r\nRange: bytes=80-5"
+    let rawRequest = "GET /someRoute HTTP/1.1\r\nRange: bytes=80-5\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!
 
     let route = Route(allowedMethods: [.Get])

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -9,7 +9,7 @@ class TwoHundredResponderTest: XCTestCase {
   let ok = TwoHundred.Ok
   // Compound Routes
     func testItCanGetContentWithACookiePrefix() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal")!
+      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
@@ -27,7 +27,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanGetContentWithCookiePrefixAndLogsIncluded() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal")!
+      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
@@ -51,7 +51,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanGetContentWithCookiePrefixAndDirectoryLinksAndLogsIncluded() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal")!
+      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
@@ -77,7 +77,7 @@ class TwoHundredResponderTest: XCTestCase {
 
   // CRUD functionality
     func testItCanDeliverContentsWithoutExtension() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
       let data = ResourceData(
         ["/someRoute": "I'm a file"]
       )
@@ -96,7 +96,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItReturnsEmptyResponseBodyIfNoContent() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let route = Route(allowedMethods: [.Get])
 
@@ -106,8 +106,8 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanCreateNewDataWithPost() {
-      let postRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\ncheese")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let postRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\ncheese")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let route = Route(allowedMethods: [.Get, .Post])
 
@@ -125,8 +125,8 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanUpdateExistingRouteDataWithPut() {
-      let putRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\nupdated cheese")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let putRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\n\r\nupdated cheese")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "cheese"])
 
@@ -146,8 +146,8 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanRemoveExistingRouteDataWithDelete() {
-      let deleteRequest = HTTPRequest(for: "DELETE /someRoute HTTP/1.1")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let deleteRequest = HTTPRequest(for: "DELETE /someRoute HTTP/1.1\r\n\r\n")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "cheese"])
 
@@ -163,8 +163,8 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanUpdateExistingDataWithPatch() {
-      let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\nnew cheese")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\n\r\nnew cheese")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "cheese"])
 
@@ -184,7 +184,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItSendsETagInHeaderIfPresentInRequest() {
-      let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\nIf-Match: abcde\r\nnew cheese")!
+      let patchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\nIf-Match: abcde\r\n\r\nnew cheese")!
 
       let data = ResourceData(["/someRoute": "cheese"])
 
@@ -203,7 +203,7 @@ class TwoHundredResponderTest: XCTestCase {
 
   // Other request methods
     func testItReturnsAllowedMethodsOnOptionsRequest() {
-      let request = HTTPRequest(for: "OPTIONS /someRoute HTTP/1.1")!
+      let request = HTTPRequest(for: "OPTIONS /someRoute HTTP/1.1\r\n\r\n")!
 
       let route = Route(allowedMethods: [.Options, .Post, .Head])
 
@@ -218,7 +218,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItCanHandleHeadRequests() {
-      let request = HTTPRequest(for: "HEAD /someRoute HTTP/1.1")!
+      let request = HTTPRequest(for: "HEAD /someRoute HTTP/1.1\r\n\r\n")!
 
       let route = Route(allowedMethods: [.Head])
 
@@ -231,8 +231,8 @@ class TwoHundredResponderTest: XCTestCase {
 
   // Edge cases
     func testItCanUpdateNonExistingData() {
-      let putRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\nupdated cheese")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
+      let putRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\n\r\nupdated cheese")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
       let route = Route(allowedMethods: [.Get, .Put])
 
@@ -251,8 +251,7 @@ class TwoHundredResponderTest: XCTestCase {
     }
 
     func testItDoesNotAppendAdditionalDataToImage() {
-      let rawRequest = "GET /someRoute.jpeg HTTP/1.1\r\nCookie: type=oatmeal"
-      let request = HTTPRequest(for: rawRequest)!
+      let request = HTTPRequest(for: "GET /someRoute.jpeg HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
 
       let data = ResourceData(["/someRoute.jpeg": "this is an image file"])
 
@@ -264,6 +263,25 @@ class TwoHundredResponderTest: XCTestCase {
         status: ok,
         headers: ["Content-Type": "image/jpeg"],
         body: "this is an image file"
+      )
+
+      XCTAssertEqual(response, expectedResponse)
+    }
+
+    func testItTreatsMissingBodyOnPostRequestsAsEmptyString() {
+      let missingBodyPostRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\n")!
+      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
+
+      let route = Route(allowedMethods: [.Post, .Get])
+
+      let responder = TwoHundredResponder(route: route)
+      let _ = responder.response(to: missingBodyPostRequest)
+      let response = responder.response(to: getRequest)
+
+      let expectedResponse = HTTPResponse(
+        status: ok,
+        headers: ["Content-Type": "text/html"],
+        body: ""
       )
 
       XCTAssertEqual(response, expectedResponse)

--- a/Tests/ResponseFormattersTests/CookieFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/CookieFormatterTest.swift
@@ -7,7 +7,7 @@ class CookieFormatterTest: XCTestCase {
   let ok = TwoHundred.Ok
 
   func testItCanAppendCookiePrefixWhenNoCookieExistsYet() {
-    let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n")!
+    let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "Eat"
 
@@ -23,7 +23,7 @@ class CookieFormatterTest: XCTestCase {
   }
 
   func testItCanAppendToExistingResponse() {
-    let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n")!
+    let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok, headers: ["Content-Type": "text/html"], body: "some stuff")
     let cookiePrefix = "Eat"
 
@@ -42,7 +42,7 @@ class CookieFormatterTest: XCTestCase {
   }
 
   func testItCanAppendCookiePrefixAfterCookieIsSet() {
-    let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\nCookie: type=chocolate")!
+    let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "wow"
 
@@ -57,7 +57,7 @@ class CookieFormatterTest: XCTestCase {
   }
 
   func testItCanSetCookieAndRespondWithCookie() {
-    let request = HTTPRequest(for: "GET /eat_cookie?type=oatmeal HTTP/1.1\r\nCookie: type=chocolate")!
+    let request = HTTPRequest(for: "GET /eat_cookie?type=oatmeal HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "wow"
 
@@ -73,7 +73,7 @@ class CookieFormatterTest: XCTestCase {
   }
 
   func testItWillNotAppendIfNoCookieHeader() {
-    let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\n")!
+    let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "wow"
 

--- a/Tests/ResponseFormattersTests/PartialFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/PartialFormatterTest.swift
@@ -9,7 +9,7 @@ class PartialFormatterTest: XCTestCase {
   let content = "This is a file that contains text to read part of in order to fulfill a 206.\n"
 
   func testItCanUpdateBodyOnResponseGivenRangeStart() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=4-")!
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=4-\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 
@@ -26,7 +26,7 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItCanUpdateBodyOnResponseGivenRangeEnd() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=-6")!
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=-6\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 
@@ -43,7 +43,7 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItCanUpdateBodyOnResponseGiveRangeStartAndEnd() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=0-4")!
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=0-4\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 
@@ -59,7 +59,7 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItReturnsTheResponseBodyAsIsIfNoRangeGiven() {
-    let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n"
+    let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!
     let response = HTTPResponse(status: ok, body: content)
 

--- a/Tests/UtilTests/ResourceDataTest.swift
+++ b/Tests/UtilTests/ResourceDataTest.swift
@@ -4,14 +4,14 @@ import Responses
 
 class ControllerDataTest: XCTestCase {
   func testItHasAGetter() {
-    let contents: [String: BytesRepresentable] = ["file1": "I'm a text file"]
+    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     XCTAssertEqual(data["file1"]!.toBytes, "I'm a text file".toBytes)
   }
 
   func testItCanMutateValues() {
-    let contents: [String: BytesRepresentable] = ["file1": "I'm a text file"]
+    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     data.update("file1", withVal: "I'm a modified text file")
@@ -20,13 +20,31 @@ class ControllerDataTest: XCTestCase {
   }
 
   func testMutationsPersistToReferences() {
-    let contents: [String: BytesRepresentable] = ["file1": "I'm a text file"]
+    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
-    let referenceToData: [ResourceData] = [data]
+    let referenceToData = data
 
     data.update("file1", withVal: "I'm a modified text file")
 
-    XCTAssertEqual(referenceToData.first!["file1"]!.toBytes, "I'm a modified text file".toBytes)
+    XCTAssertEqual(referenceToData["file1"]!.toBytes, "I'm a modified text file".toBytes)
+  }
+
+  func testItUnwrapsUpdateOptionalToEmptyStringIfNil() {
+    let contents = ["file1": "I'm a text file"]
+    let data = ResourceData(contents)
+
+    data.update("file1", withVal: nil)
+
+    XCTAssertEqual(data["file1"]!.toBytes, "".toBytes)
+  }
+
+  func testItRemovesValue() {
+    let contents = ["file1": "I'm a text file"]
+    let data = ResourceData(contents)
+
+    data.remove(at: "file1")
+
+    XCTAssertNil(data["file1"])
   }
 }


### PR DESCRIPTION
- Adjust tests to test with crlf in accordance with HTTP/1.1 protocol
- Adjust HTTPRequest to be more robust when parsing request string and assigning properties
- ResourceData to unwrap optional string to empty string when nil on update function