### PR TITLE
Close #159: FourHundredResponder BadRequest on missing body in POST/PUT/PATCH

### DIFF
--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -12,6 +12,12 @@ public struct HTTPRequest {
 
   public var headers: [String: String] = [:]
 
+  public var shouldHaveBody: Bool {
+    return self.verb == .Post ||
+            self.verb == .Patch ||
+              self.verb == .Put
+  }
+
   public init?(for rawRequest: String) {
     let splitRequest = rawRequest.components(separatedBy: crlf)
     let requestTail = splitRequest[splitRequest.index(before: splitRequest.endIndex)]
@@ -64,4 +70,5 @@ public struct HTTPRequest {
 
     return mutableResult
   }
+
 }

--- a/Sources/Responders/FourHundredResponder.swift
+++ b/Sources/Responders/FourHundredResponder.swift
@@ -27,6 +27,10 @@ class FourHundredResponder {
       return HTTPResponse(status: FourHundred.MethodNotAllowed)
     }
 
+    if request.shouldHaveBody, request.body == nil {
+      return HTTPResponse(status: FourHundred.BadRequest)
+    }
+
     if let resource = data[request.path], isRangeOutOfBounds(for: resource.count, rangeHeader) {
       let byteMax = resource.count - 1
 

--- a/Sources/Util/ResourceData.swift
+++ b/Sources/Util/ResourceData.swift
@@ -15,7 +15,11 @@ public class ResourceData {
   }
 
   public func update(_ key: String, withVal value: String?) {
-    contents.updateValue(value ?? "", forKey: key)
+    guard let validValue = value else {
+      return
+    }
+
+    contents.updateValue(validValue, forKey: key)
   }
 
   public func remove(at key: String) {

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -142,4 +142,14 @@ class RequestTest: XCTestCase {
       XCTAssertEqual(request.headers, [:])
       XCTAssertEqual(request.body!, "data:fatcat")
     }
+
+    func testItCanSayWhetherItShouldHaveABody() {
+      let postRequest = HTTPRequest(for: "POST /cookie HTTP/1.1\r\n\r\n")!
+      let putRequest = HTTPRequest(for: "PUT /cookie HTTP/1.1\r\n\r\n")!
+      let patchRequest = HTTPRequest(for: "PATCH /cookie HTTP/1.1\r\n\r\n")!
+
+      XCTAssert(postRequest.shouldHaveBody)
+      XCTAssert(putRequest.shouldHaveBody)
+      XCTAssert(patchRequest.shouldHaveBody)
+    }
 }

--- a/Tests/RespondersTests/FourHundredResponderTest.swift
+++ b/Tests/RespondersTests/FourHundredResponderTest.swift
@@ -36,6 +36,26 @@ class FourHundredResponderTest: XCTestCase {
     XCTAssertEqual(response, expectedResponse)
   }
 
+  func testItReturnsABadRequestIfPostPatchOrPutIsMissingBody() {
+    let invalidPostRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\n")!
+    let invalidPutRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\n\r\n")!
+    let invalidPatchRequest = HTTPRequest(for: "PATCH /someRoute HTTP/1.1\r\n\r\n")!
+
+    let route = Route(allowedMethods: [.Post, .Put, .Patch])
+
+    let responder = FourHundredResponder(route: route)
+
+    let postResponse = responder.response(to: invalidPostRequest)
+    let putResponse = responder.response(to: invalidPutRequest)
+    let patchResponse = responder.response(to: invalidPatchRequest)
+
+    let expectedResponse = HTTPResponse(status: FourHundred.BadRequest)
+
+    XCTAssertEqual(postResponse, expectedResponse)
+    XCTAssertEqual(putResponse, expectedResponse)
+    XCTAssertEqual(patchResponse, expectedResponse)
+  }
+
   func testItReturnsA416IfGivenEndRangeIsOutOfBounds() {
     let rawRequest = "GET /someRoute HTTP/1.1\r\nRange: bytes=5-80\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -268,22 +268,4 @@ class TwoHundredResponderTest: XCTestCase {
       XCTAssertEqual(response, expectedResponse)
     }
 
-    func testItTreatsMissingBodyOnPostRequestsAsEmptyString() {
-      let missingBodyPostRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\n")!
-      let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
-
-      let route = Route(allowedMethods: [.Post, .Get])
-
-      let responder = TwoHundredResponder(route: route)
-      let _ = responder.response(to: missingBodyPostRequest)
-      let response = responder.response(to: getRequest)
-
-      let expectedResponse = HTTPResponse(
-        status: ok,
-        headers: ["Content-Type": "text/html"],
-        body: ""
-      )
-
-      XCTAssertEqual(response, expectedResponse)
-    }
 }

--- a/Tests/UtilTests/ResourceDataTest.swift
+++ b/Tests/UtilTests/ResourceDataTest.swift
@@ -30,13 +30,13 @@ class ControllerDataTest: XCTestCase {
     XCTAssertEqual(referenceToData["file1"]!.toBytes, "I'm a modified text file".toBytes)
   }
 
-  func testItUnwrapsUpdateOptionalToEmptyStringIfNil() {
+  func testItDoesNotUpdateWhenPassedNil() {
     let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     data.update("file1", withVal: nil)
 
-    XCTAssertEqual(data["file1"]!.toBytes, "".toBytes)
+    XCTAssertEqual(data["file1"]!.toBytes, "I'm a text file".toBytes)
   }
 
   func testItRemovesValue() {


### PR DESCRIPTION
 - Conditional in FourHundredResponder to return BadRequest if POST/PUT/PATCH request is missing body
- getter in HTTPRequest to return whether verb is either POST, PUT, or PATCH.