### PR TITLE
Close #164: BytesRepresentable + Operator

### DIFF
--- a/Sources/Requests/HTTPRequestMethod.swift
+++ b/Sources/Requests/HTTPRequestMethod.swift
@@ -1,3 +1,11 @@
 public enum HTTPRequestMethod: String {
   case Get, Post, Put, Delete, Patch, Options, Head
+
+  public init?(verb: String?) {
+    guard let validVerb = verb else {
+      return nil
+    }
+
+    self.init(rawValue: validVerb)
+  }
 }

--- a/Sources/Requests/String+Extension.swift
+++ b/Sources/Requests/String+Extension.swift
@@ -7,4 +7,15 @@ extension String {
 
     self.init(result.trimmingCharacters(in: .newlines))
   }
+
+  public func prepend(_ value: String) -> String {
+    return value + self
+  }
+
+  public func trimAndRemoveMultiples(of value: String) -> String {
+    return self
+             .components(separatedBy: value)
+             .filter { !$0.isEmpty }
+             .joined(separator: value)
+  }
 }

--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -35,7 +35,7 @@ public class CookieFormatter: ResponseFormatter {
   }
 
   private func formatBody(_ cookieBody: String?) -> String? {
-    let prefixedBody = request.params.map { _ in prefix }
+    let prefixedBody = request.params != nil ? prefix : nil
 
     return cookieBody.map {
       $0 + " " + (prefixedBody ?? "")

--- a/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
+++ b/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
@@ -29,7 +29,7 @@ public class DirectoryLinksFormatter: ResponseFormatter {
   }
 
   private func trimSlash(in file: String) -> String {
-    return file.substring(from: file.index(after: file.startIndex))
+    return String(file.characters.dropFirst())
   }
 
   private func htmlLink(_ file: String) -> String {

--- a/Sources/ResponseFormatters/PartialFormatter.swift
+++ b/Sources/ResponseFormatters/PartialFormatter.swift
@@ -27,9 +27,9 @@ public class PartialFormatter: ResponseFormatter {
   }
 
   private func rangeOf(_ currentBody: String, range: String) -> String {
-    let chars = Array(currentBody.characters).map { String($0) }
+    let chars = currentBody.characters.map { String($0) }
 
-    let range = calculateRange(length: currentBody.characters.count)
+    let range = calculateRange(length: currentBody.count)
 
     return chars[range].joined(separator: "")
   }

--- a/Sources/Responses/BytesRepresentable.swift
+++ b/Sources/Responses/BytesRepresentable.swift
@@ -12,3 +12,7 @@ public extension BytesRepresentable {
   }
 
 }
+
+public func + (lhs: BytesRepresentable, rhs: BytesRepresentable?) -> BytesRepresentable {
+  return lhs.plus(rhs)
+}

--- a/Sources/Responses/HTTPResponse+Equatable.swift
+++ b/Sources/Responses/HTTPResponse+Equatable.swift
@@ -1,4 +1,5 @@
 extension HTTPResponse: Equatable {
+
   static public func == (lhs: HTTPResponse, rhs: HTTPResponse) -> Bool {
     switch (lhs, rhs) {
     default:
@@ -10,4 +11,5 @@ extension HTTPResponse: Equatable {
                 lhs.body?.toBytes ?? [] == rhs.body?.toBytes ?? []
     }
   }
+
 }

--- a/Sources/Util/MockCalender.swift
+++ b/Sources/Util/MockCalender.swift
@@ -11,10 +11,16 @@ public class MockCalendar: Calendarizable {
     self.second = second
   }
 
-  public func currentHour(from today: Date) -> Int { return hour }
+  public func currentHour(from today: Date) -> Int {
+    return hour
+  }
 
-  public func currentMinute(from today: Date) -> Int { return minute }
+  public func currentMinute(from today: Date) -> Int {
+    return minute
+  }
 
-  public func currentSecond(from today: Date) -> Int { return second }
+  public func currentSecond(from today: Date) -> Int {
+    return second
+  }
 }
 

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -152,4 +152,16 @@ class RequestTest: XCTestCase {
       XCTAssert(putRequest.shouldHaveBody)
       XCTAssert(patchRequest.shouldHaveBody)
     }
+
+    func testItWillFailIfPathHasNoLeadingSlash() {
+      let request = HTTPRequest(for: "GET someRoute HTTP/1.1\r\n\r\n")
+
+      XCTAssertNil(request)
+    }
+
+    func testItWillFormatPathWithMultipleSlashesOrTrailingSlash() {
+      let request = HTTPRequest(for: "GET //someRoute//to///////somewhere/ HTTP/1.1\r\n\r\n")!
+
+      XCTAssertEqual(request.path, "/someRoute/to/somewhere")
+    }
 }


### PR DESCRIPTION
  - global + operator func in BytesRepresentable
  - Remove all unsafe references in HTTPRequest init method,
  - create prepend and trimAndRemoveMultiples member methods to String extension in Requests
  - extend failable init to HTTPRequestMethod enum.