### PR TITLE
HTTPRequest path formatting refactor

### DIFF
--- a/Sources/Config/Config.swift
+++ b/Sources/Config/Config.swift
@@ -2,7 +2,6 @@ import Responses
 import Routes
 
 public let logsPath = "/Users/patrickwentz/8th-light/projects/swift/server/Sources/Server/Debug"
-public let defaultPublicDirPath = "/Users/patrickwentz/cob_spec/public"
 public let authCredentials = "YWRtaW46aHVudGVyMg=="
 public let defaultPort: UInt16 = 5000
 

--- a/Sources/FileIO/DirectoryReader.swift
+++ b/Sources/FileIO/DirectoryReader.swift
@@ -9,11 +9,11 @@ public class DirectoryReader {
   }
 
   public func getFileNames(at path: String) throws -> [String] {
-    guard path == defaultPublicDirPath else {
+    do {
+      return try fileManager.contentsOfDirectory(atPath: path)
+    } catch {
       throw ServerStartError.InvalidPublicDirectoryGiven
     }
-
-    return try fileManager.contentsOfDirectory(atPath: path)
   }
 
 }

--- a/Sources/Requests/HTTPParameters.swift
+++ b/Sources/Requests/HTTPParameters.swift
@@ -1,13 +1,14 @@
 public class HTTPParameters {
-  public let keyValueSeparator: String = "="
-  public let multipleSeparator: String = "&"
+  public let keyValueSeparator = "="
+  public let multipleSeparator = "&"
   public var keys: [String] = []
   public var values: [String] = []
 
   public init?(for rawParams: String) {
-    let flattenedParams = rawParams.components(separatedBy: multipleSeparator)
-                                   .flatMap { $0.components(separatedBy: keyValueSeparator) }
-                                   .filter { !$0.isEmpty }
+    let flattenedParams = rawParams
+                            .components(separatedBy: multipleSeparator)
+                            .flatMap { $0.components(separatedBy: keyValueSeparator) }
+                            .filter { !$0.isEmpty }
 
     guard flattenedParams.count >= 2 else {
       return nil

--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -19,19 +19,20 @@ public struct HTTPRequest {
   }
 
   public init?(for rawRequest: String) {
+    guard rawRequest.contains(transferProtocol) else {
+      return nil
+    }
+
     let splitRequest = rawRequest.components(separatedBy: crlf)
     let requestTail = splitRequest.last
 
     let requestLineParts = splitRequest.first?.components(separatedBy: " ")
 
-    guard let splitRequestLine = requestLineParts, splitRequestLine.count >= 2 else {
+    guard let splitRequestLine = requestLineParts, splitRequestLine.count >= 3 else {
       return nil
     }
 
-    let fullPath = splitRequestLine
-                     .first(where: { $0.hasPrefix("/") })?
-                     .trimAndRemoveMultiples(of: "/")
-                     .prepend("/")
+    let fullPath = splitRequestLine.first(where: { $0.hasPrefix("/") })
 
     guard let validPath = fullPath else {
       return nil
@@ -58,7 +59,7 @@ public struct HTTPRequest {
 
   private func requestHeaders(_ result: [String: String], _ rawHeader: String) -> [String: String] {
     var mutableResult = result
-    let separatorIndex = rawHeader.range(of: ":")
+    let separatorIndex = rawHeader.range(of: headerDivide)
 
     let key = separatorIndex.map {
       rawHeader.substring(to: $0.lowerBound)

--- a/Sources/Requests/String+Extension.swift
+++ b/Sources/Requests/String+Extension.swift
@@ -8,14 +8,4 @@ extension String {
     self.init(result.trimmingCharacters(in: .newlines))
   }
 
-  public func prepend(_ value: String) -> String {
-    return value + self
-  }
-
-  public func trimAndRemoveMultiples(of value: String) -> String {
-    return self
-             .components(separatedBy: value)
-             .filter { !$0.isEmpty }
-             .joined(separator: value)
-  }
 }

--- a/Sources/Responders/Responder.swift
+++ b/Sources/Responders/Responder.swift
@@ -2,5 +2,5 @@ import Requests
 import Responses
 
 public protocol Responder {
-  func getResponse(to request: HTTPRequest) -> HTTPResponse
+  func response(to request: HTTPRequest) -> HTTPResponse
 }

--- a/Sources/Responders/RouteResponder.swift
+++ b/Sources/Responders/RouteResponder.swift
@@ -15,7 +15,7 @@ public class RouteResponder: Responder {
     self.data = data
   }
 
-  public func getResponse(to request: HTTPRequest) -> HTTPResponse {
+  public func response(to request: HTTPRequest) -> HTTPResponse {
     guard let route = routes[request.path] else {
       return HTTPResponse(status: FourHundred.NotFound)
     }

--- a/Sources/Responders/TwoHundredResponder.swift
+++ b/Sources/Responders/TwoHundredResponder.swift
@@ -20,7 +20,7 @@ class TwoHundredResponder {
     switch request.verb {
 
     case let verb where verb == .Get:
-      let formatters = getFormatters(request: request, route: route)
+      let formatters = gatherFormatters(request: request, route: route)
 
       return isAnImage(request.path) ?
         formatters.first!.addToResponse(successResponse) :
@@ -52,7 +52,6 @@ class TwoHundredResponder {
 
       return HTTPResponse(status: TwoHundred.NoContent, headers: headers)
 
-
     case let verb where verb == .Delete:
       data.remove(at: request.path)
       return successResponse
@@ -62,7 +61,7 @@ class TwoHundredResponder {
     }
   }
 
-  private func getFormatters(request: HTTPRequest, route: Route) -> [ResponseFormatter] {
+  private func gatherFormatters(request: HTTPRequest, route: Route) -> [ResponseFormatter] {
     return [
       ContentFormatter(for: request.path, data: data),
       route.cookiePrefix.map { CookieFormatter(for: request, prefix: $0) } ?? ParamsFormatter(for: request.params),

--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -16,7 +16,7 @@ public class CookieFormatter: ResponseFormatter {
       "\(prefix) \(getCookieValue(from: cookie))"
     }
 
-    let cookieHeaders = request.params.flatMap { params -> [String: String]? in
+    let cookieHeaders = request.params.flatMap { params in
       String(params: params).map { ["Set-Cookie": $0] }
     }
 

--- a/Sources/ResponseFormatters/PartialFormatter.swift
+++ b/Sources/ResponseFormatters/PartialFormatter.swift
@@ -15,9 +15,10 @@ public class PartialFormatter: ResponseFormatter {
       return response
     }
 
-    let partialBody = response.body
-                              .flatMap { String(bytes: $0) }
-                              .map { rangeOf($0, range: validRange) }
+    let partialBody = response
+                        .body
+                        .flatMap { String(responseBody: $0) }
+                        .map { rangeOf($0, range: validRange) }
 
     return HTTPResponse(
       status: TwoHundred.PartialContent,
@@ -39,7 +40,7 @@ public class PartialFormatter: ResponseFormatter {
 
     let rangeEnd = parsedRange.end ?? contentLength - 1
 
-    let rangeStart = parsedRange.start  ?? contentLength - rangeEnd
+    let rangeStart = parsedRange.start ?? contentLength - rangeEnd
 
     return rangeEnd < rangeStart ? rangeStart..<contentLength
                                  : rangeStart..<rangeEnd + 1

--- a/Sources/Responses/BytesRepresentable.swift
+++ b/Sources/Responses/BytesRepresentable.swift
@@ -5,14 +5,6 @@ public protocol BytesRepresentable {
   var count: Int { get }
 }
 
-public extension BytesRepresentable {
-
-  func plus(_ rhs: BytesRepresentable?) -> BytesRepresentable {
-    return Data(bytes: self.toBytes + (rhs?.toBytes ?? []))
-  }
-
-}
-
 public func + (lhs: BytesRepresentable, rhs: BytesRepresentable?) -> BytesRepresentable {
-  return lhs.plus(rhs)
+  return Data(bytes: lhs.toBytes + (rhs?.toBytes ?? []))
 }

--- a/Sources/Responses/String+BytesRepresentable.swift
+++ b/Sources/Responses/String+BytesRepresentable.swift
@@ -13,17 +13,13 @@ public extension String {
   }
 
   init(response: HTTPResponse) {
-    let joinedHeaders = response.headers?
-                                .map { $0 + response.headerDivide + $1 }
-                                .joined(separator: response.crlf) ?? ""
-
     let statusLine = "\(response.transferProtocol) \(response.status.description + response.crlf)"
 
-    self.init(statusLine + joinedHeaders)!
+    self.init(statusLine + (response.joinedHeaders ?? "") + response.crlf)!
   }
 
-  init?(bytes: BytesRepresentable) {
-    self.init(bytes: bytes.toBytes, encoding: .utf8)
+  init?(responseBody: BytesRepresentable) {
+    self.init(bytes: responseBody.toBytes, encoding: .utf8)
   }
 
 }

--- a/Sources/Router/Router.swift
+++ b/Sources/Router/Router.swift
@@ -33,7 +33,7 @@ public class Router {
       let request = try HTTPRequest(for: data.toString())
       let badRequestResponse = HTTPResponse(status: FourHundred.BadRequest)
 
-      let response = request.map { responder.getResponse(to: $0) } ?? badRequestResponse
+      let response = request.map { responder.response(to: $0) } ?? badRequestResponse
 
       let timestamp = dateHelper.formatTimestamp(prefix: "SUCCESS")
 

--- a/Sources/Routes/Route.swift
+++ b/Sources/Routes/Route.swift
@@ -31,7 +31,7 @@ public class Route {
   }
 
   public func canRespondTo(_ verb: HTTPRequestMethod?) -> Bool {
-    return verb.map { self.allowedMethods.contains($0) } ?? false
+    return verb.map { allowedMethods.contains($0) } ?? false
   }
 
 }

--- a/Tests/FileIOTests/DirectoryReaderTest.swift
+++ b/Tests/FileIOTests/DirectoryReaderTest.swift
@@ -4,7 +4,7 @@ import Errors
 
 class FileReaderTest: XCTestCase {
   func testItCanReadFileNames() {
-    let path = "/Users/patrickwentz/cob_spec/public"
+    let path = "/valid/path/to/contents"
     let fileManager = MockFileManager()
 
     let fileReader = DirectoryReader(fileManager)
@@ -14,7 +14,7 @@ class FileReaderTest: XCTestCase {
     XCTAssertEqual(result, ["file1", "file2"])
   }
 
-  func testItThrowsIfPathIsNotCobSpecPath() throws {
+  func testItThrowsIfPathIsInvalid() throws {
     let path = "/some/random/path"
     let fileManager = MockFileManager()
 

--- a/Tests/FileIOTests/MockFileManager.swift
+++ b/Tests/FileIOTests/MockFileManager.swift
@@ -1,7 +1,16 @@
+import Foundation
 import FileIO
+
+enum MockError: Error {
+  case CannotReadDirectoryContents
+}
 
 class MockFileManager: FileIO {
   func contentsOfDirectory(atPath path: String) throws -> [String] {
+    guard path == "/valid/path/to/contents" else {
+      throw MockError.CannotReadDirectoryContents
+    }
+
     return ["file1", "file2"]
   }
 }

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -154,14 +154,14 @@ class RequestTest: XCTestCase {
     }
 
     func testItWillFailIfPathHasNoLeadingSlash() {
-      let request = HTTPRequest(for: "GET someRoute HTTP/1.1\r\n\r\n")
+      let request = HTTPRequest(for: "GET someRoute/to/somewhere HTTP/1.1\r\n\r\n")
 
       XCTAssertNil(request)
     }
 
-    func testItWillFormatPathWithMultipleSlashesOrTrailingSlash() {
-      let request = HTTPRequest(for: "GET //someRoute//to///////somewhere/ HTTP/1.1\r\n\r\n")!
+    func testItWillFailIfNoProtocolIsNotHTTPOnePointOne() {
+      let request = HTTPRequest(for: "GET /someRoute HTTP/5.0\r\n\r\n")
 
-      XCTAssertEqual(request.path, "/someRoute/to/somewhere")
+      XCTAssertNil(request)
     }
 }

--- a/Tests/RespondersTests/RouteResponderTest.swift
+++ b/Tests/RespondersTests/RouteResponderTest.swift
@@ -13,7 +13,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(auth: "XYZ", allowedMethods: [.Get])
       let routes = ["/logs": route]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response.status.description, "404 Not Found")
     }
@@ -24,7 +24,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(allowedMethods: [.Get])
       let routes = ["/logs": route]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response.status.description, "405 Method Not Allowed")
     }
@@ -36,7 +36,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(auth: "XYZ", allowedMethods: [.Get])
       let routes = ["/logs": route]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response.status.description, "401 Unauthorized")
     }
@@ -48,7 +48,7 @@ class RouteResponderTest: XCTestCase {
       let redirectRoute = Route(allowedMethods: [.Get])
       let routes = ["/logs": route, "/redirect": redirectRoute]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response.status.description, "302 Found")
     }
@@ -61,7 +61,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(allowedMethods: [.Get], customResponse: customResponse)
       let routes = ["/logs": route]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response, customResponse)
     }
@@ -72,7 +72,7 @@ class RouteResponderTest: XCTestCase {
       let route = Route(allowedMethods: [.Get])
       let routes = ["/logs": route]
 
-      let response = RouteResponder(routes: routes).getResponse(to: request)
+      let response = RouteResponder(routes: routes).response(to: request)
 
       XCTAssertEqual(response.status.description, "200 OK")
     }
@@ -88,8 +88,8 @@ class RouteResponderTest: XCTestCase {
 
       let responder = RouteResponder(routes: routes)
 
-      let _ = responder.getResponse(to: invalidRequest)
-      let response = responder.getResponse(to: request)
+      let _ = responder.response(to: invalidRequest)
+      let response = responder.response(to: request)
 
       let expectedResponse = HTTPResponse(
         status: TwoHundred.Ok,

--- a/Tests/ResponsesTests/ResponseTest.swift
+++ b/Tests/ResponsesTests/ResponseTest.swift
@@ -88,7 +88,7 @@ class ResponseTest: XCTestCase {
     let headers = ["Content-Type": "ABCD"]
 
     let response = HTTPResponse(status: ok, headers: headers)
-    let expected = "HTTP/1.1 200 OK\r\nContent-Type:ABCD"
+    let expected = "HTTP/1.1 200 OK\r\nContent-Type:ABCD\r\n\r\n"
 
     XCTAssertEqual(String(response: response), expected)
   }

--- a/Tests/RouterTests/RouterTest.swift
+++ b/Tests/RouterTests/RouterTest.swift
@@ -7,7 +7,7 @@ import FileIO
 import Util
 
 class MockResponder: Responder {
-  public func getResponse(to request: HTTPRequest) -> HTTPResponse {
+  public func response(to request: HTTPRequest) -> HTTPResponse {
     return HTTPResponse(status: TwoHundred.Ok)
   }
 }
@@ -61,7 +61,7 @@ class RouterTest: XCTestCase {
     try router.listen(onReceive: listenCallback)
     try router.receive()
 
-    let expectedContents = "REQUEST: GET /logs HTTP/1.1\r\n\r\n\r\nRESPONSE: HTTP/1.1 200 OK\r\n"
+    let expectedContents = "REQUEST: GET /logs HTTP/1.1\r\n\r\n\r\nRESPONSE: HTTP/1.1 200 OK\r\n\r\n"
 
     XCTAssertEqual(mockCaller.writtenContent, expectedContents)
   }


### PR DESCRIPTION
- DirectoryReader to throw if reading of files fails,
- remove unnecessary path parsing from previous commit
- HTTPRequest throws if HTTP/1.1 is not in request-line.