### PR TITLE
Close #163: Content-Range header for PartialFormatter

### DIFF
--- a/Sources/Config/Config.swift
+++ b/Sources/Config/Config.swift
@@ -6,12 +6,12 @@ public let authCredentials = "YWRtaW46aHVudGVyMg=="
 public let defaultPort: UInt16 = 5000
 
 public var routes: [String: Route] = [
-  "/logs": Route(auth: authCredentials, includeLogs: true, allowedMethods: [.Get]),
+  "/logs": Route(allowedMethods: [.Get], auth: authCredentials, includeLogs: true),
   "/log": Route(allowedMethods: [.Get]),
   "/these": Route(allowedMethods: [.Put]),
   "/requests": Route(allowedMethods: [.Head]),
-  "/cookie": Route(cookiePrefix: "Eat", allowedMethods: [.Get]),
-  "/eat_cookie": Route(cookiePrefix: "mmmm", allowedMethods: [.Get]),
+  "/cookie": Route(allowedMethods: [.Get], cookiePrefix: "Eat"),
+  "/eat_cookie": Route(allowedMethods: [.Get], cookiePrefix: "mmmm"),
   "/coffee": Route(
     allowedMethods: [.Get],
     customResponse: HTTPResponse(status: FourHundred.Teapot, body: "I'm a teapot")),

--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -34,27 +34,29 @@ public struct HTTPRequest {
 
     let fullPath = splitRequestLine.first(where: { $0.hasPrefix("/") })
 
-    guard let validPath = fullPath else {
+    guard let path = fullPath else {
       return nil
     }
 
-    verb = HTTPRequestMethod(verb: splitRequestLine.first?.capitalized)
+    self.verb = splitRequestLine
+                  .first
+                  .flatMap { HTTPRequestMethod(rawValue: $0.capitalized) }
 
-    path = validPath
-             .range(of: parameterDivide)
-             .flatMap { validPath.substring(to: $0.lowerBound) } ?? validPath
+    self.path = path
+                 .range(of: parameterDivide)
+                 .flatMap { path.substring(to: $0.lowerBound) } ?? path
 
-    params = validPath
-               .components(separatedBy: parameterDivide)
-               .first(where: { $0.contains("=") })
-               .flatMap { HTTPParameters(for: $0) }
+    self.params = path
+                   .components(separatedBy: parameterDivide)
+                   .first(where: { $0.contains("=") })
+                   .flatMap(HTTPParameters.init)
 
-    body = requestTail.flatMap { $0.isEmpty ? nil : $0 }
+    self.body = requestTail.flatMap { $0.isEmpty ? nil : $0 }
 
-    headers = splitRequest
-               .dropFirst()
-               .dropLast()
-               .reduce([:], requestHeaders)
+    self.headers = splitRequest
+                     .dropFirst()
+                     .dropLast()
+                     .reduce([:], requestHeaders)
   }
 
   private func requestHeaders(_ result: [String: String], _ rawHeader: String) -> [String: String] {

--- a/Sources/Requests/HTTPRequestMethod.swift
+++ b/Sources/Requests/HTTPRequestMethod.swift
@@ -1,11 +1,3 @@
 public enum HTTPRequestMethod: String {
   case Get, Post, Put, Delete, Patch, Options, Head
-
-  public init?(verb: String?) {
-    guard let validVerb = verb else {
-      return nil
-    }
-
-    self.init(rawValue: validVerb)
-  }
 }

--- a/Sources/Responders/ThreeHundredResponder.swift
+++ b/Sources/Responders/ThreeHundredResponder.swift
@@ -10,7 +10,7 @@ class ThreeHundredResponder {
   }
 
   func response(to request: HTTPRequest) -> HTTPResponse? {
-    return redirectPath.map { foundResponse(location: $0) }
+    return redirectPath.map(foundResponse)
   }
 
   private func foundResponse(location: String) -> HTTPResponse {

--- a/Sources/Responders/TwoHundredResponder.swift
+++ b/Sources/Responders/TwoHundredResponder.swift
@@ -19,14 +19,14 @@ class TwoHundredResponder {
     let successResponse = HTTPResponse(status: TwoHundred.Ok)
     switch request.verb {
 
-    case let verb where verb == .Get:
+    case .some(.Get):
       let formatters = gatherFormatters(request: request, route: route)
 
       return isAnImage(request.path) ?
         formatters.first!.addToResponse(successResponse) :
         formatters.reduce(successResponse) { $1.addToResponse($0) }
 
-    case let verb where verb == .Options:
+    case .some(.Options):
       let allowedMethods = route
                             .allowedMethods
                             .map { $0.rawValue.uppercased() }
@@ -34,11 +34,11 @@ class TwoHundredResponder {
 
       return HTTPResponse(status: TwoHundred.Ok, headers: ["Allow": allowedMethods])
 
-    case let verb where verb == .Post:
+    case .some(.Post):
       data.update(request.path, withVal: request.body)
       return successResponse
 
-    case let verb where verb == .Put:
+    case .some(.Put):
       let resource = data[request.path]
       data.update(request.path, withVal: request.body)
 
@@ -46,13 +46,13 @@ class TwoHundredResponder {
         HTTPResponse(status: TwoHundred.Created) :
         successResponse
 
-    case let verb where verb == .Patch:
+    case .some(.Patch):
       data.update(request.path, withVal: request.body)
       let headers = request.headers["if-match"].map { ["ETag": $0] }
 
       return HTTPResponse(status: TwoHundred.NoContent, headers: headers)
 
-    case let verb where verb == .Delete:
+    case .some(.Delete):
       data.remove(at: request.path)
       return successResponse
 

--- a/Sources/ResponseFormatters/ContentFormatter.swift
+++ b/Sources/ResponseFormatters/ContentFormatter.swift
@@ -17,7 +17,9 @@ public class ContentFormatter: ResponseFormatter {
       return response
     }
 
-    let newHeaders = ["Content-Type": getContentType()]
+    let newHeaders = [
+      "Content-Type": path.range(of: ".").map(contentType) ?? "text/html"
+    ]
 
     let newResponse = HTTPResponse(
       status: response.status,
@@ -28,12 +30,10 @@ public class ContentFormatter: ResponseFormatter {
     return response + newResponse
   }
 
-  private func getContentType() -> String {
-    return path.range(of: ".").map { extStart -> String in
-      let ext = path.substring(from: extStart.upperBound)
+  private func contentType(_ extStart: Range<String.Index>) -> String {
+    let ext = path.substring(from: extStart.upperBound)
 
-      return isAnImage(ext) ? "image/\(ext)" : "text/plain"
-    } ?? "text/html"
+    return isAnImage(ext) ? "image/\(ext)" : "text/plain"
   }
 
 }

--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -12,13 +12,14 @@ public class CookieFormatter: ResponseFormatter {
   }
 
   public func addToResponse(_ response: HTTPResponse) -> HTTPResponse {
-    let cookieBody = request.headers["cookie"].map { cookie in
-      "\(prefix) \(getCookieValue(from: cookie))"
-    }
+    let cookieBody = request
+                       .headers["cookie"]
+                       .map(toPrefixedCookie)
 
-    let cookieHeaders = request.params.flatMap { params in
-      String(params: params).map { ["Set-Cookie": $0] }
-    }
+    let cookieHeaders = request
+                         .params
+                         .flatMap(String.init)
+                         .map { ["Set-Cookie": $0] }
 
     let newResponse = HTTPResponse(
       status: response.status,
@@ -29,9 +30,9 @@ public class CookieFormatter: ResponseFormatter {
     return response + newResponse
   }
 
-  private func getCookieValue(from cookieHeader: String) -> String {
-    let separatedCookie = cookieHeader.components(separatedBy: "=")
-    return separatedCookie[separatedCookie.index(before: separatedCookie.endIndex)]
+  private func toPrefixedCookie(_ cookie: String) -> String {
+    let cookieVal = cookie.components(separatedBy: "=").last
+    return prefix + " " + (cookieVal ?? "")
   }
 
   private func formatBody(_ cookieBody: String?) -> String? {

--- a/Sources/Responses/HTTPResponse+Equatable.swift
+++ b/Sources/Responses/HTTPResponse+Equatable.swift
@@ -8,7 +8,7 @@ extension HTTPResponse: Equatable {
 
       return lhs.status.description == rhs.status.description &&
               leftHeaders == rightHeaders &&
-                lhs.body?.toBytes ?? [] == rhs.body?.toBytes ?? []
+                (lhs.body?.toBytes ?? []) == (rhs.body?.toBytes ?? [])
     }
   }
 

--- a/Sources/Responses/HTTPResponse.swift
+++ b/Sources/Responses/HTTPResponse.swift
@@ -14,7 +14,7 @@ public struct HTTPResponse {
   }
 
   public static func + (lhs: HTTPResponse, rhs: HTTPResponse) -> HTTPResponse {
-    let newBody = lhs.mergeBody(with: rhs.body)
+    let newBody = rhs.body.flatMap(lhs.mergeBody)
     let newHeaders = lhs.mergeHeaders(with: rhs.headers)
 
     return HTTPResponse(status: rhs.status, headers: newHeaders, body: newBody)
@@ -39,7 +39,7 @@ public struct HTTPResponse {
     ).toBytes
   }
 
-  private func mergeBody(with newBody: BytesRepresentable?) -> BytesRepresentable? {
+  private func mergeBody(with newBody: BytesRepresentable) -> BytesRepresentable? {
     return self.body.map { $0 + "\n\n" + newBody } ?? newBody
   }
 

--- a/Sources/Router/Router.swift
+++ b/Sources/Router/Router.swift
@@ -33,7 +33,7 @@ public class Router {
       let request = try HTTPRequest(for: data.toString())
       let badRequestResponse = HTTPResponse(status: FourHundred.BadRequest)
 
-      let response = request.map { responder.response(to: $0) } ?? badRequestResponse
+      let response = request.map(responder.response) ?? badRequestResponse
 
       let timestamp = dateHelper.formatTimestamp(prefix: "SUCCESS")
 

--- a/Sources/Routes/Route.swift
+++ b/Sources/Routes/Route.swift
@@ -1,7 +1,7 @@
 import Requests
 import Responses
 
-public class Route {
+public struct Route {
   public let auth: String?
   public let cookiePrefix: String?
   public let includeLogs: Bool
@@ -10,11 +10,11 @@ public class Route {
   public let redirectPath: String?
   public let customResponse: HTTPResponse?
 
-  public init(auth: String? = nil, cookiePrefix: String? = nil, includeLogs: Bool = false, allowedMethods: [HTTPRequestMethod], includeDirectoryLinks: Bool = false, redirectPath: String? = nil) {
+  public init(allowedMethods: [HTTPRequestMethod], auth: String? = nil, cookiePrefix: String? = nil, includeLogs: Bool = false, includeDirectoryLinks: Bool = false, redirectPath: String? = nil) {
+    self.allowedMethods = allowedMethods
     self.auth = auth
     self.cookiePrefix = cookiePrefix
     self.includeLogs = includeLogs
-    self.allowedMethods = allowedMethods
     self.includeDirectoryLinks = includeDirectoryLinks
     self.redirectPath = redirectPath
     self.customResponse = nil
@@ -31,7 +31,7 @@ public class Route {
   }
 
   public func canRespondTo(_ verb: HTTPRequestMethod?) -> Bool {
-    return verb.map { allowedMethods.contains($0) } ?? false
+    return verb.map(allowedMethods.contains) ?? false
   }
 
 }

--- a/Tests/RespondersTests/FourHundredResponderTest.swift
+++ b/Tests/RespondersTests/FourHundredResponderTest.swift
@@ -6,7 +6,7 @@ import Requests
 import Util
 
 class FourHundredResponderTest: XCTestCase {
-  let route = Route(auth: "XYZ", allowedMethods: [.Get], redirectPath: "/")
+  let route = Route(allowedMethods: [.Get], auth: "XYZ", redirectPath: "/")
 
   func testItReturns401WhenAuthDoesntMatch() {
     let rawRequest = "GET /someRoute HTTP/1.1\r\nAuthorization: Basic ABC\r\n\r\n"

--- a/Tests/RespondersTests/RouteResponderTest.swift
+++ b/Tests/RespondersTests/RouteResponderTest.swift
@@ -10,7 +10,7 @@ class RouteResponderTest: XCTestCase {
   // Early Returns
     func testItReturnsA404IfRouteIsNotSpecified() {
       let request = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
-      let route = Route(auth: "XYZ", allowedMethods: [.Get])
+      let route = Route(allowedMethods: [.Get], auth: "XYZ")
       let routes = ["/logs": route]
 
       let response = RouteResponder(routes: routes).response(to: request)
@@ -33,7 +33,7 @@ class RouteResponderTest: XCTestCase {
       let rawRequest = "GET /logs HTTP/1.1\r\nAuthorization: Basic someencodedstuff=="
       let request = HTTPRequest(for: rawRequest)!
 
-      let route = Route(auth: "XYZ", allowedMethods: [.Get])
+      let route = Route(allowedMethods: [.Get], auth: "XYZ")
       let routes = ["/logs": route]
 
       let response = RouteResponder(routes: routes).response(to: request)
@@ -83,7 +83,7 @@ class RouteResponderTest: XCTestCase {
       let invalidRequest = HTTPRequest(for: "HELLO /someRoute HTTP/1.1")!
       let request = HTTPRequest(for: "GET /someRoute HTTP/1.1")!
 
-      let route = Route(includeLogs: true, allowedMethods: [.Get])
+      let route = Route(allowedMethods: [.Get], includeLogs: true)
       let routes = ["/someRoute": route]
 
       let responder = RouteResponder(routes: routes)

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -13,7 +13,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
-      let route = Route(cookiePrefix: "neat", allowedMethods: [.Get])
+      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat")
 
       let response = TwoHundredResponder(route: route, data: data).response(to: request)
 
@@ -31,7 +31,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
-      let route = Route(cookiePrefix: "neat", includeLogs: true, allowedMethods: [.Get])
+      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true)
       let logs = ["GET /someRoute HTTP/1.1"]
 
       let responder = TwoHundredResponder(route: route, data: data, logs: logs)
@@ -55,7 +55,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
-      let route = Route(cookiePrefix: "neat", includeLogs: true, allowedMethods: [.Get], includeDirectoryLinks: true)
+      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true, includeDirectoryLinks: true)
       let logs = ["GET /someRoute HTTP/1.1"]
 
       let responder = TwoHundredResponder(route: route, data: data, logs: logs)
@@ -255,7 +255,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute.jpeg": "this is an image file"])
 
-      let route = Route(cookiePrefix: "neat", includeLogs: true, allowedMethods: [.Get], includeDirectoryLinks: true)
+      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true, includeDirectoryLinks: true)
 
       let response = TwoHundredResponder(route: route, data: data).response(to: request)
 

--- a/Tests/ResponseFormattersTests/DirectoryLinksFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/DirectoryLinksFormatterTest.swift
@@ -37,7 +37,7 @@ class DirectoryLinksFormatterTest: XCTestCase {
   }
 
   func testItDoesNotAddDirectoryLinksIfFilesAreNil() {
-    let response = HTTPResponse(status: TwoHundred.Ok)
+    let response = HTTPResponse(status: ok)
 
     let newResponse = DirectoryLinksFormatter(files: nil).addToResponse(response)
 
@@ -45,11 +45,16 @@ class DirectoryLinksFormatterTest: XCTestCase {
   }
 
   func testItReturnsNewResponseBodyAsIsIfFilesAreNil() {
-    let response = HTTPResponse(status: TwoHundred.Ok, body: "neat!")
+    let response = HTTPResponse(status: ok, body: "neat!")
 
     let newResponse = DirectoryLinksFormatter(files: nil).addToResponse(response)
 
-    XCTAssertEqual(newResponse.body!.toBytes, "neat!".toBytes)
+    let expectedResponse = HTTPResponse(
+      status: ok,
+      body: "neat!"
+    )
+
+    XCTAssertEqual(newResponse, expectedResponse)
   }
 
   func testItDoesNotAppendHTMLDataWhenContentTypeIsText() {

--- a/Tests/ResponseFormattersTests/PartialFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/PartialFormatterTest.swift
@@ -19,6 +19,7 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
+      headers: ["Content-Range": "bytes 4-76/77"],
       body: " is a file that contains text to read part of in order to fulfill a 206.\n"
     )
 
@@ -36,6 +37,7 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
+      headers: ["Content-Range": "bytes 71-76/77"],
       body: " 206.\n"
     )
 
@@ -52,13 +54,14 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
+      headers: ["Content-Range": "bytes 0-4/77"],
       body: "This "
     )
 
     XCTAssertEqual(newResponse, expectedResponse)
   }
 
-  func testItReturnsTheResponseBodyAsIsIfNoRangeGiven() {
+  func testItReturnsTheResponseAsIsIfNoRangeGiven() {
     let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n\r\n"
     let request = HTTPRequest(for: rawRequest)!
     let response = HTTPResponse(status: ok, body: content)

--- a/Tests/ResponsesTests/ResponseTest.swift
+++ b/Tests/ResponsesTests/ResponseTest.swift
@@ -56,12 +56,12 @@ class ResponseTest: XCTestCase {
 
     let rfcDateHeader = "\r\nDate: Fri, 21 Apr 2017\r\n\r\n"
     let body = "BODY"
-    let formattedStatus = "HTTP/1.1 200 OK\r\n".toBytes
-    let formattedResponse = formattedStatus + (rawHeaders + rfcDateHeader).toBytes + body.toBytes
+    let formattedStatus = "HTTP/1.1 200 OK\r\n"
+    let formattedResponse = formattedStatus + rawHeaders + rfcDateHeader + body
 
     let response = HTTPResponse(status: ok, headers: headers, body: body)
 
-    XCTAssertEqual(response.format(dateHelper: dateHelper), formattedResponse)
+    XCTAssertEqual(response.format(dateHelper: dateHelper), formattedResponse.toBytes)
   }
 
   func testItCanFormatItselfWithNoBody() {
@@ -77,11 +77,11 @@ class ResponseTest: XCTestCase {
 
     let rfcDateHeader = "\r\nDate: Fri, 21 Apr 2017\r\n\r\n"
 
-    let formattedResponse = "HTTP/1.1 200 OK\r\n".toBytes + (rawHeaders + rfcDateHeader).toBytes + []
+    let formattedResponse = "HTTP/1.1 200 OK\r\n" + rawHeaders + rfcDateHeader
 
     let response = HTTPResponse(status: ok, headers: headers)
 
-    XCTAssertEqual(response.format(dateHelper: dateHelper), formattedResponse)
+    XCTAssertEqual(response.format(dateHelper: dateHelper), formattedResponse.toBytes)
   }
 
   func testItsStatusAndHeadersCanBeRepresentedByAString() {


### PR DESCRIPTION
  - Implement Content-Range header in PartialFormatter
  - move allowedMethods in Route to be first params since it is only required.
  - Remove unsafe array index in CookieFormatter,
  - cleaner expression of optional in switch statement in TwoHundredResponder.
  - replace trailing closure maps for function references where necessary.