### PR TITLE
Close #169: Remove compound cookie functionality

### DIFF
--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -21,10 +21,12 @@ public class CookieFormatter: ResponseFormatter {
                          .flatMap(String.init)
                          .map { ["Set-Cookie": $0] }
 
+    let prefixedBody = request.params != nil ? prefix : nil
+
     let newResponse = HTTPResponse(
       status: response.status,
       headers: cookieHeaders,
-      body: formatBody(cookieBody)
+      body: cookieBody ?? prefixedBody
     )
 
     return response + newResponse
@@ -32,15 +34,7 @@ public class CookieFormatter: ResponseFormatter {
 
   private func toPrefixedCookie(_ cookie: String) -> String {
     let cookieVal = cookie.components(separatedBy: "=").last
-    return prefix + " " + (cookieVal ?? "")
-  }
-
-  private func formatBody(_ cookieBody: String?) -> String? {
-    let prefixedBody = request.params != nil ? prefix : nil
-
-    return cookieBody.map {
-      $0 + " " + (prefixedBody ?? "")
-    }?.trimmingCharacters(in: .whitespaces) ?? prefixedBody
+    return "\(prefix) \(cookieVal ?? "")"
   }
 
 }

--- a/Sources/ResponseFormatters/PartialFormatter.swift
+++ b/Sources/ResponseFormatters/PartialFormatter.swift
@@ -31,12 +31,10 @@ public class PartialFormatter: ResponseFormatter {
     return HTTPResponse(
       status: TwoHundred.PartialContent,
       headers: newHeaders,
-      body: givenRange.flatMap { originalContent.map(toChars)?[$0] }?.joined(separator: "")
+      body: givenRange.flatMap { range in
+        originalContent.map(chars)?[range].joined(separator: "")
+      }
     )
-  }
-
-  private func toChars(_ body: String) -> [String] {
-    return body.characters.map { String($0) }
   }
 
   private func calculateRange(length contentLength: Int) -> Range<Int> {
@@ -46,6 +44,10 @@ public class PartialFormatter: ResponseFormatter {
 
     return rangeEnd < rangeStart ? rangeStart..<contentLength
                                  : rangeStart..<rangeEnd + 1
+  }
+
+  private func chars(_ body: String) -> [String] {
+    return body.characters.map { String($0) }
   }
 
 }

--- a/Sources/Responses/HTTPResponse.swift
+++ b/Sources/Responses/HTTPResponse.swift
@@ -14,7 +14,7 @@ public struct HTTPResponse {
   }
 
   public static func + (lhs: HTTPResponse, rhs: HTTPResponse) -> HTTPResponse {
-    let newBody = rhs.body.flatMap(lhs.mergeBody)
+    let newBody = lhs.mergeBody(with: rhs.body)
     let newHeaders = lhs.mergeHeaders(with: rhs.headers)
 
     return HTTPResponse(status: rhs.status, headers: newHeaders, body: newBody)
@@ -39,7 +39,7 @@ public struct HTTPResponse {
     ).toBytes
   }
 
-  private func mergeBody(with newBody: BytesRepresentable) -> BytesRepresentable? {
+  private func mergeBody(with newBody: BytesRepresentable?) -> BytesRepresentable? {
     return self.body.map { $0 + "\n\n" + newBody } ?? newBody
   }
 

--- a/Tests/RequestsTests/ParamsTest.swift
+++ b/Tests/RequestsTests/ParamsTest.swift
@@ -206,7 +206,7 @@ class ParamsTest: XCTestCase {
     let expected = ["variable_1": "Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "variable_2": "stuff"]
     let result = [String: String](params: params)
 
-    XCTAssertEqual(result, expected)
+      XCTAssertEqual(result, expected)
   }
 
   func testItCanHandleNonEncodedParams() {

--- a/Tests/ResponseFormattersTests/CookieFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/CookieFormatterTest.swift
@@ -41,7 +41,7 @@ class CookieFormatterTest: XCTestCase {
     XCTAssertEqual(newResponse, expectedResponse)
   }
 
-  func testItCanAppendCookiePrefixAfterCookieIsSet() {
+  func testItCanPrependCookiePrefixAfterCookieIsSet() {
     let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "wow"
@@ -56,7 +56,7 @@ class CookieFormatterTest: XCTestCase {
     XCTAssertEqual(newResponse, expectedResponse)
   }
 
-  func testItCanSetCookieAndRespondWithCookie() {
+  func testItPrependsCookiePrefixIfParamsArePresent() {
     let request = HTTPRequest(for: "GET /eat_cookie?type=oatmeal HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
     let cookiePrefix = "wow"
@@ -66,7 +66,7 @@ class CookieFormatterTest: XCTestCase {
     let expectedResponse = HTTPResponse(
       status: ok,
       headers: ["Set-Cookie": "type=oatmeal"],
-      body: "wow chocolate wow"
+      body: "wow chocolate"
     )
 
     XCTAssertEqual(newResponse, expectedResponse)


### PR DESCRIPTION
- Remove extra private formatting func in CookieFormatter
- CF only returns route-defined prefix + cookie header value if passed params and cookie header.