### PR TITLE
Close #167: Content-Length Header

### DIFF
--- a/Sources/Requests/HTTPParameters.swift
+++ b/Sources/Requests/HTTPParameters.swift
@@ -7,7 +7,7 @@ public class HTTPParameters {
   public init?(for rawParams: String) {
     let flattenedParams = rawParams
                             .components(separatedBy: multipleSeparator)
-                            .flatMap { $0.components(separatedBy: keyValueSeparator) }
+                            .flatMap(separateKeyValuePair)
                             .filter { !$0.isEmpty }
 
     guard flattenedParams.count >= 2 else {
@@ -25,6 +25,10 @@ public class HTTPParameters {
         values.append(decode(param))
       }
     }
+  }
+
+  private func separateKeyValuePair(_ rawParameter: String) -> [String] {
+    return rawParameter.components(separatedBy: keyValueSeparator)
   }
 
   private func decode(_ rawParams: String) -> String {

--- a/Sources/Requests/HTTPRequest.swift
+++ b/Sources/Requests/HTTPRequest.swift
@@ -5,9 +5,9 @@ public struct HTTPRequest {
   public let verb: HTTPRequestMethod?
   public let body: String?
   public let params: HTTPParameters?
-  public let crlf: String = "\r\n"
-  public let headerDivide: String = ":"
-  public let transferProtocol: String = "HTTP/1.1"
+  private let crlf: String = "\r\n"
+  private let headerDivide: String = ":"
+  private let transferProtocol: String = "HTTP/1.1"
   private let parameterDivide: String = "?"
 
   public var headers: [String: String] = [:]

--- a/Sources/Responders/TwoHundredResponder.swift
+++ b/Sources/Responders/TwoHundredResponder.swift
@@ -9,6 +9,13 @@ class TwoHundredResponder {
   let data: ResourceData
   let logs: [String]
 
+  private var allowedMethods: String {
+    return route
+            .allowedMethods
+            .map { $0.rawValue.uppercased() }
+            .joined(separator: ",")
+  }
+
   public init(route: Route, data: ResourceData = EmptyResourceData(), logs: [String] = []) {
     self.route = route
     self.data = data
@@ -27,11 +34,6 @@ class TwoHundredResponder {
         formatters.reduce(successResponse) { $1.addToResponse($0) }
 
     case .some(.Options):
-      let allowedMethods = route
-                            .allowedMethods
-                            .map { $0.rawValue.uppercased() }
-                            .joined(separator: ",")
-
       return HTTPResponse(status: TwoHundred.Ok, headers: ["Allow": allowedMethods])
 
     case .some(.Post):

--- a/Sources/ResponseFormatters/ContentFormatter.swift
+++ b/Sources/ResponseFormatters/ContentFormatter.swift
@@ -17,23 +17,27 @@ public class ContentFormatter: ResponseFormatter {
       return response
     }
 
-    let newHeaders = [
-      "Content-Type": path.range(of: ".").map(contentType) ?? "text/html"
-    ]
+    let contentType = path
+                       .range(of: ".")
+                       .map(getContentType)
 
     let newResponse = HTTPResponse(
       status: response.status,
-      headers: newHeaders,
+      headers: [
+        "Content-Type": contentType ?? "text/html"
+      ],
       body: resource
     )
 
     return response + newResponse
   }
 
-  private func contentType(_ extStart: Range<String.Index>) -> String {
+  private func getContentType(_ extStart: Range<String.Index>) -> String {
     let ext = path.substring(from: extStart.upperBound)
 
-    return isAnImage(ext) ? "image/\(ext)" : "text/plain"
+    return isAnImage(ext) ?
+            "image/\(ext)" :
+            "text/plain"
   }
 
 }

--- a/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
+++ b/Sources/ResponseFormatters/DirectoryLinksFormatter.swift
@@ -17,8 +17,9 @@ public class DirectoryLinksFormatter: ResponseFormatter {
       return response
     }
 
-    let formattedLinks = fileNames.map(htmlLink)
-                                  .joined(separator: "<br>")
+    let formattedLinks = fileNames
+                          .map(htmlLink)
+                          .joined(separator: "<br>")
 
     let newResponse = HTTPResponse(
       status: response.status,

--- a/Sources/ResponseFormatters/PartialFormatter.swift
+++ b/Sources/ResponseFormatters/PartialFormatter.swift
@@ -4,50 +4,44 @@ import Responses
 import Util
 
 public class PartialFormatter: ResponseFormatter {
-  let range: String?
-  private let parsedRange: (start: Int?, end: Int?)
+  let givenRange: String?
 
-  public init(for range: String?) {
-    self.range = range
-    self.parsedRange = parseRangeHeader(range)
+  public init(for givenRange: String?) {
+    self.givenRange = givenRange
   }
 
   public func addToResponse(_ response: HTTPResponse) -> HTTPResponse {
-    guard range != nil else {
+    let existingBody = response.body.flatMap(String.init)
+
+    guard givenRange != nil, let defaultContent = existingBody else {
       return response
     }
 
-    let originalContent = response.body.flatMap(String.init)
-    let contentLength = originalContent?.count
-    let givenRange = contentLength.map(calculateRange)
+    let fullLength = defaultContent.count
+    let range = calculateRange(length: fullLength)
 
-    let newHeaders = givenRange.map { rnge -> [String: String] in
-      let length: Any = contentLength ?? "*"
-      return [
-        "Content-Range": "bytes \(rnge.lowerBound)-\(rnge.upperBound - 1)/\(length)"
-      ]
-    }
+    let partialBody = defaultContent.chars[range].joined(separator: "")
+
+    let newHeaders = [
+      "Content-Range": "bytes \(range.lowerBound)-\(range.upperBound - 1)/\(fullLength)",
+      "Content-Length": "\(partialBody.count)"
+    ]
 
     return HTTPResponse(
       status: TwoHundred.PartialContent,
       headers: newHeaders,
-      body: givenRange.flatMap { range in
-        originalContent.map(chars)?[range].joined(separator: "")
-      }
+      body: partialBody
     )
   }
 
   private func calculateRange(length contentLength: Int) -> Range<Int> {
+    let parsedRange = parseRangeHeader(givenRange)
     let rangeEnd = parsedRange.end ?? contentLength - 1
 
     let rangeStart = parsedRange.start ?? contentLength - rangeEnd
 
     return rangeEnd < rangeStart ? rangeStart..<contentLength
                                  : rangeStart..<rangeEnd + 1
-  }
-
-  private func chars(_ body: String) -> [String] {
-    return body.characters.map { String($0) }
   }
 
 }

--- a/Sources/Responses/String+BytesRepresentable.swift
+++ b/Sources/Responses/String+BytesRepresentable.swift
@@ -12,6 +12,10 @@ public extension String {
     return self.characters.count
   }
 
+  var chars: [String] {
+    return self.characters.map { String($0) }
+  }
+
   init(response: HTTPResponse) {
     let statusLine = "\(response.transferProtocol) \(response.status.description + response.crlf)"
 

--- a/Tests/FileIOTests/DirectoryReaderTest.swift
+++ b/Tests/FileIOTests/DirectoryReaderTest.swift
@@ -3,12 +3,10 @@ import XCTest
 import Errors
 
 class FileReaderTest: XCTestCase {
+  let fileReader = DirectoryReader(MockFileManager())
+
   func testItCanReadFileNames() {
     let path = "/valid/path/to/contents"
-    let fileManager = MockFileManager()
-
-    let fileReader = DirectoryReader(fileManager)
-
     let result = try! fileReader.getFileNames(at: path)
 
     XCTAssertEqual(result, ["file1", "file2"])
@@ -16,9 +14,6 @@ class FileReaderTest: XCTestCase {
 
   func testItThrowsIfPathIsInvalid() throws {
     let path = "/some/random/path"
-    let fileManager = MockFileManager()
-
-    let fileReader = DirectoryReader(fileManager)
 
     XCTAssertThrowsError(try fileReader.getFileNames(at: path)) { error in
       XCTAssertEqual(error as! ServerStartError, ServerStartError.InvalidPublicDirectoryGiven)

--- a/Tests/RequestsTests/ParamsTest.swift
+++ b/Tests/RequestsTests/ParamsTest.swift
@@ -3,171 +3,132 @@ import XCTest
 
 class ParamsTest: XCTestCase {
   func testItCanBeAString() {
-    let fullPath = "my=params"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params")!
 
     XCTAssertEqual(String(params: params)!, "my=params")
   }
 
   func testItCanBeADynamicString() {
-    let fullPath = "type=oatmeal"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=oatmeal")!
 
     XCTAssertEqual(String(params: params)!, "type=oatmeal")
   }
 
   func testItHasKeys() {
-    let fullPath = "type=oatmeal"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=oatmeal")!
 
     XCTAssertEqual(params.keys, ["type"])
   }
 
   func testItHasDynamicKeys() {
-    let fullPath = "my=params"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params")!
 
     XCTAssertEqual(params.keys, ["my"])
   }
 
   func testItHasValues() {
-    let fullPath = "type=oatmeal"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=oatmeal")!
 
     XCTAssertEqual(params.values, ["oatmeal"])
   }
 
   func testItHasDynamicValues() {
-    let fullPath = "type=chocolate"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=chocolate")!
 
     XCTAssertEqual(params.values, ["chocolate"])
   }
 
   func testItCantHandleSingleMissingValue() {
-    let fullPath = "type="
-
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: "type=")
 
     XCTAssertNil(params)
   }
 
   func testItCanHandleNestedBlankParamValuesToString() {
-    let fullPath = "type=chocolate&wow="
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=chocolate&wow=")!
 
     XCTAssertEqual(String(params: params)!, "type=chocolate")
   }
 
   func testItCanHandleNestedBlankParamKeysToString() {
-    let fullPath = "type=chocolate&=wow"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=chocolate&=wow")!
 
     XCTAssertEqual(String(params: params)!, "type=chocolate")
   }
 
   func testItCantHandleSingleMissingKey() {
-    let fullPath = "=stuff"
-
-    let params = HTTPParameters(for: fullPath)
+    let params = HTTPParameters(for: "=stuff")
 
     XCTAssertNil(params)
   }
 
   func testItCanHandleNestedInvalidParamsToDict() {
-    let path = "type=chocolate&stuff="
-    let params = HTTPParameters(for: path)!
+    let params = HTTPParameters(for: "type=chocolate&stuff=")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["type": "chocolate"])
   }
 
   func testItCanHandleNestedInvalidParamsKeys() {
-    let path = "type=chocolate&stuff="
-    let params = HTTPParameters(for: path)!
+    let params = HTTPParameters(for: "type=chocolate&stuff=")!
 
     XCTAssertEqual(params.keys, ["type"])
   }
 
   func testItCanHandleNestedInvalidParamsVals() {
-    let path = "type=chocolate&=stuff"
-    let params = HTTPParameters(for: path)!
+    let params = HTTPParameters(for: "type=chocolate&=stuff")!
 
     XCTAssertEqual(params.values, ["chocolate"])
   }
 
   func testItCanConvertToDictionary() {
-    let fullPath = "type=oatmeal"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "type=oatmeal")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["type": "oatmeal"])
   }
 
   func testItCanDynamicallyConvertToDictionary() {
-    let fullPath = "my=params"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["my": "params"])
   }
 
   func testItCanHandleMultipleParamsToString() {
-    let fullPath = "my=params&cool=stuff"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&cool=stuff")!
 
     XCTAssertEqual(String(params: params)!, "my=params\ncool=stuff")
   }
 
   func testItCanHandleMultipleParamsKeys() {
-    let fullPath = "my=params&cool=stuff"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&cool=stuff")!
 
     XCTAssertEqual(params.keys, ["my", "cool"])
   }
 
   func testItCanHandleMultipleParamsVals() {
-    let fullPath = "my=params&cool=stuff"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&cool=stuff")!
 
     XCTAssertEqual(params.values, ["params", "stuff"])
   }
 
   func testItCanHandleInvalidNestedParamKeys() {
-    let fullPath = "my=params&=cool"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&=cool")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["my": "params"])
   }
 
   func testItCanHandleInvalidNestedParamVals() {
-    let fullPath = "my=params&cool"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&cool")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["my": "params"])
   }
 
   func testItCanHandleMultipleParamsToDict() {
-    let fullPath = "my=params&cool=stuff"
-
-    let params = HTTPParameters(for: fullPath)!
+    let params = HTTPParameters(for: "my=params&cool=stuff")!
     let result = [String: String](params: params)
 
     XCTAssertEqual(result, ["my": "params", "cool": "stuff"])
@@ -206,7 +167,7 @@ class ParamsTest: XCTestCase {
     let expected = ["variable_1": "Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", "variable_2": "stuff"]
     let result = [String: String](params: params)
 
-      XCTAssertEqual(result, expected)
+    XCTAssertEqual(result, expected)
   }
 
   func testItCanHandleNonEncodedParams() {

--- a/Tests/RequestsTests/RequestTest.swift
+++ b/Tests/RequestsTests/RequestTest.swift
@@ -3,115 +3,113 @@ import XCTest
 
 class RequestTest: XCTestCase {
     func testItTakesRawRequestAndExtractsVerbGET() {
-        let rawRequest = "GET /log HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let request = HTTPRequest(for: "GET /log HTTP/1.1\r\n\r\n")!
 
-        XCTAssertEqual(request.verb, .Get)
+      XCTAssertEqual(request.verb, .Get)
     }
 
     func testItTakesRawRequestAndExtractsVerbPOST() {
-        let rawRequest = "POST /log HTTP/1.1\r\n\r\ndata=stuff"
-        let request = HTTPRequest(for: rawRequest)!
+      let request = HTTPRequest(for: "POST /log HTTP/1.1\r\n\r\ndata=stuff")!
 
-        XCTAssertEqual(request.verb, .Post)
+      XCTAssertEqual(request.verb, .Post)
     }
 
     func testItTakesRawRequestAndExtractsPathLogs() {
-        let rawRequest = "GET /logs HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /logs HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
-        XCTAssertEqual(request.path, "/logs")
+      XCTAssertEqual(request.path, "/logs")
     }
 
     func testItTakesRawRequestAndExtractsAllValidHeaders() {
-        let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\nAuthorization: Basic YWRtaW46aHVudGVyMg==\r\n Connection: Keep-Alive\r\n User-Agent:Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding:gzip,deflate\r\nAccept-Charset: utf-8\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
-        let expectedResult = [
-          "host": "localhost:5000",
-          "authorization": "Basic YWRtaW46aHVudGVyMg==",
-          "connection": "Keep-Alive",
-          "user-agent": "Apache-HttpClient/4.3.5 (java 1.5)",
-          "accept-encoding": "gzip,deflate",
-          "accept-charset": "utf-8"
-        ]
+      let rawRequest = "GET /logs HTTP/1.1\r\n Host: localhost:5000\r\nAuthorization: Basic YWRtaW46aHVudGVyMg==\r\n Connection: Keep-Alive\r\n User-Agent:Apache-HttpClient/4.3.5 (java 1.5)\r\n Accept-Encoding:gzip,deflate\r\nAccept-Charset: utf-8\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+      let expectedResult = [
+        "host": "localhost:5000",
+        "authorization": "Basic YWRtaW46aHVudGVyMg==",
+        "connection": "Keep-Alive",
+        "user-agent": "Apache-HttpClient/4.3.5 (java 1.5)",
+        "accept-encoding": "gzip,deflate",
+        "accept-charset": "utf-8"
+      ]
 
-        XCTAssertEqual(request.headers, expectedResult)
+      XCTAssertEqual(request.headers, expectedResult)
     }
 
     func testItTakesRawRequestAndExtractsOnlyValidHeadersNoWhiteSpacesInHeader() {
-        let rawRequest = "GET /form HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
-        let expectedResult = [
-          "host": "yahoo.com",
-          "connection": "Keep-Alive",
-          "user-agent": "chrome",
-          "accept-encoding": "gzip,deflate"
-        ]
+      let rawRequest = "GET /form HTTP/1.1\r\nHost:yahoo.com\r\nConnection:Keep-Alive\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+      let expectedResult = [
+        "host": "yahoo.com",
+        "connection": "Keep-Alive",
+        "user-agent": "chrome",
+        "accept-encoding": "gzip,deflate"
+      ]
 
-        XCTAssertEqual(request.headers, expectedResult)
+      XCTAssertEqual(request.headers, expectedResult)
     }
 
     func testItIgnoresEmptyHeaders() {
-        let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
-        let expectedResult = [
-          "user-agent": "chrome",
-          "accept-encoding": "gzip,deflate"
-        ]
+      let rawRequest = "POST /form HTTP/1.1\r\nHost:\r\nUser-Agent:chrome\r\nAccept-Encoding:gzip,deflate\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+      let expectedResult = [
+        "user-agent": "chrome",
+        "accept-encoding": "gzip,deflate"
+      ]
 
-        XCTAssertEqual(request.headers, expectedResult)
+      XCTAssertEqual(request.headers, expectedResult)
     }
 
     func testItHasNoParams() {
-        let rawRequest = "GET /cookie HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /cookie HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
-        XCTAssertNil(request.params)
+      XCTAssertNil(request.params)
     }
 
     func testItHasInvalidParams() {
-        let rawRequest = "GET /cookie?sometihgnaksjnd HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /cookie?sometihgnaksjnd HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
-        XCTAssertNil(request.params)
+      XCTAssertNil(request.params)
     }
 
     func testItDoesntCreateParamsWithBlankValues() {
-        let rawRequest = "GET /cookie?sometihgnaksjnd= HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /cookie?sometihgnaksjnd= HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
-        XCTAssertNil(request.params)
+      XCTAssertNil(request.params)
     }
 
     func testItCanRecognizeBlankParamKey() {
-        let rawRequest = "GET /cookie?=sometihgnaksjnd HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /cookie?=sometihgnaksjnd HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
-        XCTAssertNil(request.params)
+      XCTAssertNil(request.params)
     }
 
     func testItHasParams() {
-        let rawRequest = "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
-        let result = [String: String](params: request.params!)
+      let rawRequest = "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+      let result = [String: String](params: request.params!)
 
-        XCTAssertEqual(result, ["type": "chocolate"])
+      XCTAssertEqual(result, ["type": "chocolate"])
     }
 
     func testItCanHandleDifferentParams() {
-        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
-        let result = [String: String](params: request.params!)
+      let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
+      let result = [String: String](params: request.params!)
 
-        XCTAssertEqual(result, ["roast": "beef"])
+      XCTAssertEqual(result, ["roast": "beef"])
     }
 
     func testHavingParamsDoesntChangePath() {
-        let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
-        let request = HTTPRequest(for: rawRequest)!
+      let rawRequest = "GET /cookie?roast=beef HTTP/1.1\r\n\r\n"
+      let request = HTTPRequest(for: rawRequest)!
 
 
-        XCTAssertEqual(request.path, "/cookie")
+      XCTAssertEqual(request.path, "/cookie")
     }
 
     func testItHasABody() {

--- a/Tests/ResponseFormattersTests/PartialFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/PartialFormatterTest.swift
@@ -19,7 +19,10 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
-      headers: ["Content-Range": "bytes 4-76/77"],
+      headers: [
+        "Content-Range": "bytes 4-76/77",
+        "Content-Length": "73"
+      ],
       body: " is a file that contains text to read part of in order to fulfill a 206.\n"
     )
 
@@ -37,7 +40,10 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
-      headers: ["Content-Range": "bytes 71-76/77"],
+      headers: [
+        "Content-Range": "bytes 71-76/77",
+        "Content-Length": "6"
+      ],
       body: " 206.\n"
     )
 
@@ -54,7 +60,10 @@ class PartialFormatterTest: XCTestCase {
 
     let expectedResponse = HTTPResponse(
       status: partial,
-      headers: ["Content-Range": "bytes 0-4/77"],
+      headers: [
+        "Content-Range": "bytes 0-4/77",
+        "Content-Length": "5"
+      ],
       body: "This "
     )
 
@@ -62,8 +71,7 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItReturnsTheResponseAsIsIfNoRangeGiven() {
-    let rawRequest = "GET /partial_content.txt HTTP/1.1\r\n\r\n"
-    let request = HTTPRequest(for: rawRequest)!
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok, body: content)
 
     let partialFormatter = PartialFormatter(for: request.headers["range"])

--- a/Tests/UtilTests/DateHelperTests.swift
+++ b/Tests/UtilTests/DateHelperTests.swift
@@ -13,7 +13,7 @@ class DateHelperTest: XCTestCase {
     XCTAssertEqual(timestamp, expected)
   }
 
-  func testItFormatsRFCTimestamp() {
+  func testItReturnsRFCTimestamp() {
     let mockCalendar = MockCalendar(hour: 10, minute: 45, second: 15)
     let mockFormatter = MockFormatter(month: "04", day: "21", year: "2017")
     let dateHelper = DateHelper(today: Date(), calendar: mockCalendar, formatter: mockFormatter)


### PR DESCRIPTION
  - PartialFormatter to calculate Content-Length header,
  - additional guard let in PartialFormatter to return early if response body can't be parsed to string.
  - remove extraneous variables in ParamsTest