### PR TITLE
Close #144: Test readability

### DIFF
--- a/Sources/ResponseFormatters/CookieFormatter.swift
+++ b/Sources/ResponseFormatters/CookieFormatter.swift
@@ -32,9 +32,10 @@ public class CookieFormatter: ResponseFormatter {
     return response + newResponse
   }
 
-  private func toPrefixedCookie(_ cookie: String) -> String {
+  private func toPrefixedCookie(_ cookie: String) -> BytesRepresentable {
     let cookieVal = cookie.components(separatedBy: "=").last
-    return "\(prefix) \(cookieVal ?? "")"
+
+    return prefix + " " + cookieVal
   }
 
 }

--- a/Sources/Responses/ResourceData.swift
+++ b/Sources/Responses/ResourceData.swift
@@ -31,4 +31,5 @@ public class EmptyResourceData: ResourceData {
   public init() {
     super.init([:])
   }
+
 }

--- a/Sources/Router/Router.swift
+++ b/Sources/Router/Router.swift
@@ -9,7 +9,7 @@ public class Router {
   let threadQueue: ThreadQueue
   let responder: Responder
   let dateHelper: DateHelper
-  var onReceive: ((_ timestamp: String) -> (_ content: String) throws -> Void)? = nil
+  var onReceive: ((_ timestamp: String) -> (_ content: String) throws -> Void)?
 
   public init(socket: Socket, threadQueue: ThreadQueue, port: UInt16, responder: Responder, dateHelper: DateHelper) {
     self.port = port

--- a/Tests/RespondersTests/TwoHundredResponderTest.swift
+++ b/Tests/RespondersTests/TwoHundredResponderTest.swift
@@ -7,58 +7,18 @@ import Routes
 
 class TwoHundredResponderTest: XCTestCase {
   let ok = TwoHundred.Ok
+  let configRoute = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true, includeDirectoryLinks: true)
+  let crudRoute = Route(allowedMethods: [.Options, .Get, .Put, .Post, .Patch, .Delete, .Head])
+
   // Compound Routes
-    func testItCanGetContentWithACookiePrefix() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
-
-      let data = ResourceData(["/someRoute": "this is a file."])
-
-      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat")
-
-      let response = TwoHundredResponder(route: route, data: data).response(to: request)
-
-      let expectedResponse = HTTPResponse(
-        status: ok,
-        headers: ["Content-Type": "text/html"],
-        body: ["this is a file.", "neat oatmeal"].joined(separator: "\n\n")
-      )
-
-      XCTAssertEqual(response, expectedResponse)
-    }
-
-    func testItCanGetContentWithCookiePrefixAndLogsIncluded() {
-      let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
-
-      let data = ResourceData(["/someRoute": "this is a file."])
-
-      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true)
-      let logs = ["GET /someRoute HTTP/1.1"]
-
-      let responder = TwoHundredResponder(route: route, data: data, logs: logs)
-      let response = responder.response(to: request)
-
-      let expectedResponse = HTTPResponse(
-        status: ok,
-        headers: ["Content-Type": "text/html"],
-        body: [
-          "this is a file.",
-          "neat oatmeal",
-          "GET /someRoute HTTP/1.1"
-        ].joined(separator: "\n\n")
-      )
-
-      XCTAssertEqual(response, expectedResponse)
-    }
-
     func testItCanGetContentWithCookiePrefixAndDirectoryLinksAndLogsIncluded() {
       let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\nCookie: type=oatmeal\r\n\r\n")!
 
       let data = ResourceData(["/someRoute": "this is a file."])
 
-      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true, includeDirectoryLinks: true)
       let logs = ["GET /someRoute HTTP/1.1"]
 
-      let responder = TwoHundredResponder(route: route, data: data, logs: logs)
+      let responder = TwoHundredResponder(route: configRoute, data: data, logs: logs)
       let response = responder.response(to: request)
 
       let expectedResponse = HTTPResponse(
@@ -82,9 +42,7 @@ class TwoHundredResponderTest: XCTestCase {
         ["/someRoute": "I'm a file"]
       )
 
-      let route = Route(allowedMethods: [.Get])
-
-      let response = TwoHundredResponder(route: route, data: data).response(to: request)
+      let response = TwoHundredResponder(route: crudRoute, data: data).response(to: request)
 
       let expectedResponse = HTTPResponse(
         status: ok,
@@ -98,9 +56,7 @@ class TwoHundredResponderTest: XCTestCase {
     func testItReturnsEmptyResponseBodyIfNoContent() {
       let request = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
-      let route = Route(allowedMethods: [.Get])
-
-      let response = TwoHundredResponder(route: route).response(to: request)
+      let response = TwoHundredResponder(route: crudRoute).response(to: request)
 
       XCTAssertNil(response.body)
     }
@@ -109,9 +65,7 @@ class TwoHundredResponderTest: XCTestCase {
       let postRequest = HTTPRequest(for: "POST /someRoute HTTP/1.1\r\n\r\ncheese")!
       let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
-      let route = Route(allowedMethods: [.Get, .Post])
-
-      let responder = TwoHundredResponder(route: route)
+      let responder = TwoHundredResponder(route: crudRoute)
       let _ = responder.response(to: postRequest)
       let response = responder.response(to: getRequest)
 
@@ -130,9 +84,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "cheese"])
 
-      let route = Route(allowedMethods: [.Get, .Put])
-
-      let responder = TwoHundredResponder(route: route, data: data)
+      let responder = TwoHundredResponder(route: crudRoute, data: data)
       let _ = responder.response(to: putRequest)
       let response = responder.response(to: getRequest)
 
@@ -151,9 +103,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "cheese"])
 
-      let route = Route(allowedMethods: [.Get, .Delete])
-
-      let responder = TwoHundredResponder(route: route, data: data)
+      let responder = TwoHundredResponder(route: crudRoute, data: data)
       let _ = responder.response(to: deleteRequest)
       let response = responder.response(to: getRequest)
 
@@ -168,9 +118,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "cheese"])
 
-      let route = Route(allowedMethods: [.Get, .Patch])
-
-      let responder = TwoHundredResponder(route: route, data: data)
+      let responder = TwoHundredResponder(route: crudRoute, data: data)
       let _ = responder.response(to: patchRequest)
       let response = responder.response(to: getRequest)
 
@@ -188,9 +136,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute": "cheese"])
 
-      let route = Route(allowedMethods: [.Get, .Patch])
-
-      let responder = TwoHundredResponder(route: route, data: data)
+      let responder = TwoHundredResponder(route: crudRoute, data: data)
       let response = responder.response(to: patchRequest)
 
       let expectedResponse = HTTPResponse(
@@ -205,13 +151,11 @@ class TwoHundredResponderTest: XCTestCase {
     func testItReturnsAllowedMethodsOnOptionsRequest() {
       let request = HTTPRequest(for: "OPTIONS /someRoute HTTP/1.1\r\n\r\n")!
 
-      let route = Route(allowedMethods: [.Options, .Post, .Head])
-
-      let response = TwoHundredResponder(route: route).response(to: request)
+      let response = TwoHundredResponder(route: crudRoute).response(to: request)
 
       let expectedResponse = HTTPResponse(
         status: TwoHundred.Ok,
-        headers: ["Allow": "OPTIONS,POST,HEAD"]
+        headers: ["Allow": "OPTIONS,GET,PUT,POST,PATCH,DELETE,HEAD"]
       )
 
       XCTAssertEqual(response, expectedResponse)
@@ -220,9 +164,7 @@ class TwoHundredResponderTest: XCTestCase {
     func testItCanHandleHeadRequests() {
       let request = HTTPRequest(for: "HEAD /someRoute HTTP/1.1\r\n\r\n")!
 
-      let route = Route(allowedMethods: [.Head])
-
-      let response = TwoHundredResponder(route: route).response(to: request)
+      let response = TwoHundredResponder(route: crudRoute).response(to: request)
 
       let expectedResponse = HTTPResponse(status: ok)
 
@@ -234,9 +176,7 @@ class TwoHundredResponderTest: XCTestCase {
       let putRequest = HTTPRequest(for: "PUT /someRoute HTTP/1.1\r\n\r\nupdated cheese")!
       let getRequest = HTTPRequest(for: "GET /someRoute HTTP/1.1\r\n\r\n")!
 
-      let route = Route(allowedMethods: [.Get, .Put])
-
-      let responder = TwoHundredResponder(route: route)
+      let responder = TwoHundredResponder(route: crudRoute)
       let putResponse = responder.response(to: putRequest)
       let getResponse = responder.response(to: getRequest)
 
@@ -255,9 +195,7 @@ class TwoHundredResponderTest: XCTestCase {
 
       let data = ResourceData(["/someRoute.jpeg": "this is an image file"])
 
-      let route = Route(allowedMethods: [.Get], cookiePrefix: "neat", includeLogs: true, includeDirectoryLinks: true)
-
-      let response = TwoHundredResponder(route: route, data: data).response(to: request)
+      let response = TwoHundredResponder(route: configRoute, data: data).response(to: request)
 
       let expectedResponse = HTTPResponse(
         status: ok,

--- a/Tests/ResponseFormattersTests/CookieFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/CookieFormatterTest.swift
@@ -5,11 +5,11 @@ import Responses
 
 class CookieFormatterTest: XCTestCase {
   let ok = TwoHundred.Ok
+  let cookiePrefix = "Eat"
 
   func testItCanAppendCookiePrefixWhenNoCookieExistsYet() {
     let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok)
-    let cookiePrefix = "Eat"
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
@@ -25,7 +25,6 @@ class CookieFormatterTest: XCTestCase {
   func testItCanAppendToExistingResponse() {
     let request = HTTPRequest(for: "GET /cookie?type=chocolate HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok, headers: ["Content-Type": "text/html"], body: "some stuff")
-    let cookiePrefix = "Eat"
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
@@ -44,13 +43,12 @@ class CookieFormatterTest: XCTestCase {
   func testItCanPrependCookiePrefixAfterCookieIsSet() {
     let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
-    let cookiePrefix = "wow"
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
     let expectedResponse = HTTPResponse(
       status: ok,
-      body: "wow chocolate"
+      body: "Eat chocolate"
     )
 
     XCTAssertEqual(newResponse, expectedResponse)
@@ -59,14 +57,13 @@ class CookieFormatterTest: XCTestCase {
   func testItPrependsCookiePrefixIfParamsArePresent() {
     let request = HTTPRequest(for: "GET /eat_cookie?type=oatmeal HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n")!
     let response = HTTPResponse(status: ok)
-    let cookiePrefix = "wow"
 
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
     let expectedResponse = HTTPResponse(
       status: ok,
       headers: ["Set-Cookie": "type=oatmeal"],
-      body: "wow chocolate"
+      body: "Eat chocolate"
     )
 
     XCTAssertEqual(newResponse, expectedResponse)
@@ -75,8 +72,6 @@ class CookieFormatterTest: XCTestCase {
   func testItWillNotAppendIfNoCookieHeader() {
     let request = HTTPRequest(for: "GET /eat_cookie HTTP/1.1\r\n\r\n")!
     let response = HTTPResponse(status: ok)
-    let cookiePrefix = "wow"
-
     let newResponse = CookieFormatter(for: request, prefix: cookiePrefix).addToResponse(response)
 
     XCTAssertNil(newResponse.body)

--- a/Tests/ResponseFormattersTests/PartialFormatterTest.swift
+++ b/Tests/ResponseFormattersTests/PartialFormatterTest.swift
@@ -9,7 +9,8 @@ class PartialFormatterTest: XCTestCase {
   let content = "This is a file that contains text to read part of in order to fulfill a 206.\n"
 
   func testItCanUpdateBodyOnResponseGivenRangeStart() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=4-\r\n\r\n")!
+    let range = "4-"
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=\(range)\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 
@@ -30,7 +31,8 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItCanUpdateBodyOnResponseGivenRangeEnd() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=-6\r\n\r\n")!
+    let range = "-6"
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=\(range)\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 
@@ -51,7 +53,8 @@ class PartialFormatterTest: XCTestCase {
   }
 
   func testItCanUpdateBodyOnResponseGiveRangeStartAndEnd() {
-    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=0-4\r\n\r\n")!
+    let range = "0-4"
+    let request = HTTPRequest(for: "GET /partial_content.txt HTTP/1.1\r\nRange:bytes=\(range)\r\n\r\n")!
 
     let response = HTTPResponse(status: ok, body: content)
 

--- a/Tests/ResponsesTests/ResourceDataTest.swift
+++ b/Tests/ResponsesTests/ResourceDataTest.swift
@@ -3,15 +3,14 @@ import XCTest
 import Util
 
 class ControllerDataTest: XCTestCase {
+  let contents = ["file1": "I'm a text file"]
   func testItHasAGetter() {
-    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     XCTAssertEqual(data["file1"]!.toBytes, "I'm a text file".toBytes)
   }
 
   func testItCanMutateValues() {
-    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     data.update("file1", withVal: "I'm a modified text file")
@@ -20,7 +19,6 @@ class ControllerDataTest: XCTestCase {
   }
 
   func testMutationsPersistToReferences() {
-    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     let referenceToData = data
@@ -31,7 +29,6 @@ class ControllerDataTest: XCTestCase {
   }
 
   func testItDoesNotUpdateWhenPassedNil() {
-    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     data.update("file1", withVal: nil)
@@ -40,7 +37,6 @@ class ControllerDataTest: XCTestCase {
   }
 
   func testItRemovesValue() {
-    let contents = ["file1": "I'm a text file"]
     let data = ResourceData(contents)
 
     data.remove(at: "file1")


### PR DESCRIPTION
  - Extract shared vars from individual tests in Responder and Formatters where necessary.
  - remove redundant nil assignment to optional in Router.
  - Adjust private func in CookieFormatter to return BytesRepresentable to eliminate optional unwrapping in string concatenation.